### PR TITLE
PriorityQueue interface extends Java's Queue interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-05-16
+## [Unreleased] - 2022-05-17
 
 **BREAKING CHANGES:** See changes section for details. Breaking changes include increasing
 minimum supported Java version to Java 17.
@@ -12,9 +12,8 @@ minimum supported Java version to Java 17.
 ### Added
 * DisjointSetForest: representation of disjoint sets of generic objects.
 * DisjointIntegerSetForest: representation of disjoint sets of integers with a disjoint set forest.
-* PriorityQueue: common interface to different implementations of priority queues, with sub-interfaces:
-  * PriorityQueue.Integer for int-valued priorities.
-  * PriorityQueue.Double for double-valued priorities.
+* PriorityQueue: interface to different implementations of priority queues with int-valued priorities.
+* PriorityQueueDouble: interface to different implementations of priority queues with double-valued priorities.
 * BinaryHeap: implements PriorityQueue.Integer with binary heap for both min-heap and max-heap cases.
 * BinaryHeapDouble: implements PriorityQueue.Double with binary heap for both min-heap and max-heap cases.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ minimum supported Java version to Java 17.
 * DisjointIntegerSetForest: representation of disjoint sets of integers with a disjoint set forest.
 * PriorityQueue: interface to different implementations of priority queues with int-valued priorities.
 * PriorityQueueDouble: interface to different implementations of priority queues with double-valued priorities.
-* BinaryHeap: implements PriorityQueue.Integer with binary heap for both min-heap and max-heap cases.
-* BinaryHeapDouble: implements PriorityQueue.Double with binary heap for both min-heap and max-heap cases.
+* BinaryHeap: implements PriorityQueue with binary heap for both min-heap and max-heap cases.
+* BinaryHeapDouble: implements PriorityQueueDouble with binary heap for both min-heap and max-heap cases.
 
 ### Changed
 * Minimum supported Java version is now Java 17.

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -25,6 +25,7 @@ package org.cicirello.ds;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -392,6 +393,27 @@ public class BinaryHeap<E> implements PriorityQueue<E> {
 			buffer[i] = null;
 		}
 		return true;
+	}
+	
+	@Override
+	public final boolean retainAll(Collection<?> c) {
+		HashSet<E> deleteThese = new HashSet<E>();
+		for (int i = 0; i < size; i++) {
+			deleteThese.add(buffer[i].element);
+		}
+		for (Object o : c) {
+			if (o instanceof PriorityQueueNode.Integer) {
+				PriorityQueueNode.Integer pair = (PriorityQueueNode.Integer)o;
+				deleteThese.remove(pair.element);
+			} else {
+				deleteThese.remove(o);
+			}
+		}
+		boolean changed = false;
+		for (E e : deleteThese) {
+			changed = remove(e) | changed;
+		}
+		return changed;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -63,7 +63,8 @@ import java.util.NoSuchElementException;
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, int)}, {@link #offer(PriorityQueueNode.Integer)},
  *     {@link #poll}, {@link #pollElement}, {@link #remove(Object)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
- *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
+ *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #toArray()}, {@link #toArray(Object[])}, 
+ *     {@link #trimToSize}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the BinaryHeap.
@@ -71,7 +72,7 @@ import java.util.NoSuchElementException;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
+public class BinaryHeap<E> implements PriorityQueue<E> {
 	
 	private PriorityQueueNode.Integer<E>[] buffer;
 	private int size;

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -60,7 +60,7 @@ import java.util.NoSuchElementException;
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(Object)},
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, int)}, {@link #offer(PriorityQueueNode.Integer)},
- *     {@link #poll}, {@link #pollElement}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #remove(Object)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
  *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
  * </ul>

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -411,7 +411,7 @@ public class BinaryHeap<E> implements PriorityQueue<E> {
 		}
 		boolean changed = false;
 		for (E e : deleteThese) {
-			changed = remove(e) | changed;
+changed = remove(e) || changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -57,10 +57,10 @@ import java.util.NoSuchElementException;
  * <ul>
  * <li><b>O(1):</b> {@link #contains}, {@link #createMaxHeap()}, {@link #createMaxHeap(int)},
  *     {@link #createMinHeap()}, {@link #createMinHeap(int)}, {@link #isEmpty}, {@link #iterator},
- *     {@link #peek}, {@link #peekPair}, {@link #peekPriority()}, {@link #peekPriority(Object)},
+ *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(Object)},
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, int)}, {@link #offer(PriorityQueueNode.Integer)},
- *     {@link #poll}, {@link #pollPair}</li>
+ *     {@link #poll}, {@link #pollElement}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
  *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
  * </ul>
@@ -70,7 +70,7 @@ import java.util.NoSuchElementException;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class BinaryHeap<E> implements PriorityQueue.Integer<E>, Iterable<PriorityQueueNode.Integer<E>> {
+public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 	
 	private PriorityQueueNode.Integer<E>[] buffer;
 	private int size;
@@ -322,12 +322,12 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E>, Iterable<Priorit
 	}
 	
 	@Override
-	public final E peek() {
+	public final E peekElement() {
 		return size > 0 ? buffer[0].element : null;
 	}
 	
 	@Override
-	public final PriorityQueueNode.Integer<E> peekPair() {
+	public final PriorityQueueNode.Integer<E> peek() {
 		return size > 0 ? buffer[0] : null;
 	}
 	
@@ -343,13 +343,13 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E>, Iterable<Priorit
 	}
 	
 	@Override
-	public final E poll() {
-		PriorityQueueNode.Integer<E> min = pollPair();
+	public final E pollElement() {
+		PriorityQueueNode.Integer<E> min = poll();
 		return min != null ? min.element : null;
 	}
 	
 	@Override
-	public final PriorityQueueNode.Integer<E> pollPair() {
+	public final PriorityQueueNode.Integer<E> poll() {
 		if (size > 0) {
 			PriorityQueueNode.Integer<E> min = buffer[0];
 			index.remove(min.element);

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -366,6 +366,33 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 	}
 	
 	@Override
+	public final boolean remove(Object o) {
+		java.lang.Integer i = null;
+		if (o instanceof PriorityQueueNode.Integer) {
+			PriorityQueueNode.Integer pair = (PriorityQueueNode.Integer)o;
+			i = index.get(pair.element);
+		} else {
+			i = index.get(o);
+		}
+		if (i == null) {
+			return false;
+		}
+		index.remove(buffer[i].element);
+		size--;
+		if (size > 0 && i != size) {
+			int removedElementPriority = buffer[i].value;
+			buffer[i] = buffer[size];
+			buffer[size] = null;
+			index.put(buffer[i].element, i);
+			// percolate in relevant direction
+			percolateAfterRemoval(i, removedElementPriority);
+		} else {
+			buffer[i] = null;
+		}
+		return true;
+	}
+	
+	@Override
 	public final int size() {
 		return size;
 	}
@@ -407,6 +434,18 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 			percolateUp(i);
 		} else if (priority > buffer[i].value) {
 			buffer[i].value = priority;
+			percolateDown(i);
+		}
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	void percolateAfterRemoval(int i, int removedElementPriority) {
+		if (buffer[i].value < removedElementPriority) {
+			percolateUp(i);
+		} else if (buffer[i].value > removedElementPriority) {
 			percolateDown(i);
 		}
 	}
@@ -569,6 +608,18 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 				percolateUp(i);
 			} else if (priority < self.buffer[i].value) {
 				self.buffer[i].value = priority;
+				percolateDown(i);
+			}
+		}
+		
+		/*
+		 * override for max first order
+		 */
+		@Override
+		final void percolateAfterRemoval(int i, int removedElementPriority) {
+			if (self.buffer[i].value > removedElementPriority) {
+				percolateUp(i);
+			} else if (self.buffer[i].value < removedElementPriority) {
 				percolateDown(i);
 			}
 		}

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -411,7 +411,7 @@ public class BinaryHeap<E> implements PriorityQueue<E> {
 		}
 		boolean changed = false;
 		for (E e : deleteThese) {
-changed = remove(e) || changed;
+			changed = remove(e) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -293,13 +293,6 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 		return size == 0;
 	}
 	
-	/**
-	 * Returns an iterator over the (element, priority) pairs in a
-	 * mostly arbitrary order (i.e., you must not assume any particular
-	 * order).
-	 *
-	 * @return an iterator over the (element, priority) pairs
-	 */
 	@Override
 	public final Iterator<PriorityQueueNode.Integer<E>> iterator() {
 		return new BinaryHeapIterator();

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -227,8 +227,12 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 	}
 	
 	@Override
-	public final boolean contains(E element) {
-		return index.containsKey(element);
+	public final boolean contains(Object o) {
+		if (o instanceof PriorityQueueNode.Integer) {
+			PriorityQueueNode.Integer pair = (PriorityQueueNode.Integer)o;
+			return index.containsKey(pair.element);
+		}
+		return index.containsKey(o);
 	}
 	
 	/**

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -22,6 +22,7 @@
  
 package org.cicirello.ds;
 
+import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Arrays;
@@ -395,6 +396,30 @@ public class BinaryHeap<E> implements PriorityQueue.Integer<E> {
 	@Override
 	public final int size() {
 		return size;
+	}
+	
+	@Override
+	public final Object[] toArray() {
+		Object[] array = new Object[size];
+		for (int i = 0; i < size; i++) {
+			array[i] = buffer[i];
+		}
+		return array;
+	}
+	
+	@Override
+	public final <T> T[] toArray(T[] array) {
+		@SuppressWarnings("unchecked")
+		T[] result = array.length >= size ? array : (T[])Array.newInstance(array.getClass().getComponentType(), size);
+		for (int i = 0; i < size; i++) {
+			@SuppressWarnings("unchecked")
+			T nextElement = (T)buffer[i];
+			result[i] = nextElement;
+		}
+		if (result.length > size) {
+			result[size] = null;
+		}
+		return result;
 	}
 	
 	/**

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -25,6 +25,7 @@ package org.cicirello.ds;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -392,6 +393,27 @@ public class BinaryHeapDouble<E> implements PriorityQueueDouble<E> {
 			buffer[i] = null;
 		}
 		return true;
+	}
+	
+	@Override
+	public final boolean retainAll(Collection<?> c) {
+		HashSet<E> deleteThese = new HashSet<E>();
+		for (int i = 0; i < size; i++) {
+			deleteThese.add(buffer[i].element);
+		}
+		for (Object o : c) {
+			if (o instanceof PriorityQueueNode.Double) {
+				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+				deleteThese.remove(pair.element);
+			} else {
+				deleteThese.remove(o);
+			}
+		}
+		boolean changed = false;
+		for (E e : deleteThese) {
+			changed = remove(e) | changed;
+		}
+		return changed;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -366,6 +366,33 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 	}
 	
 	@Override
+	public final boolean remove(Object o) {
+		java.lang.Integer i = null;
+		if (o instanceof PriorityQueueNode.Double) {
+			PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+			i = index.get(pair.element);
+		} else {
+			i = index.get(o);
+		}
+		if (i == null) {
+			return false;
+		}
+		index.remove(buffer[i].element);
+		size--;
+		if (size > 0 && i != size) {
+			double removedElementPriority = buffer[i].value;
+			buffer[i] = buffer[size];
+			buffer[size] = null;
+			index.put(buffer[i].element, i);
+			// percolate in relevant direction
+			percolateAfterRemoval(i, removedElementPriority);
+		} else {
+			buffer[i] = null;
+		}
+		return true;
+	}
+	
+	@Override
 	public final int size() {
 		return size;
 	}
@@ -407,6 +434,18 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 			percolateUp(i);
 		} else if (priority > buffer[i].value) {
 			buffer[i].value = priority;
+			percolateDown(i);
+		}
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	void percolateAfterRemoval(int i, double removedElementPriority) {
+		if (buffer[i].value < removedElementPriority) {
+			percolateUp(i);
+		} else if (buffer[i].value > removedElementPriority) {
 			percolateDown(i);
 		}
 	}
@@ -569,6 +608,18 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 				percolateUp(i);
 			} else if (priority < self.buffer[i].value) {
 				self.buffer[i].value = priority;
+				percolateDown(i);
+			}
+		}
+		
+		/*
+		 * override for max first order
+		 */
+		@Override
+		final void percolateAfterRemoval(int i, double removedElementPriority) {
+			if (self.buffer[i].value > removedElementPriority) {
+				percolateUp(i);
+			} else if (self.buffer[i].value < removedElementPriority) {
 				percolateDown(i);
 			}
 		}

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -57,10 +57,10 @@ import java.util.NoSuchElementException;
  * <ul>
  * <li><b>O(1):</b> {@link #contains}, {@link #createMaxHeap()}, {@link #createMaxHeap(int)},
  *     {@link #createMinHeap()}, {@link #createMinHeap(int)}, {@link #isEmpty}, {@link #iterator},
- *     {@link #peek}, {@link #peekPair}, {@link #peekPriority()}, {@link #peekPriority(Object)},
+ *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(Object)},
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, double)}, {@link #offer(PriorityQueueNode.Double)},
- *     {@link #poll}, {@link #pollPair}</li>
+ *     {@link #poll}, {@link #pollElement}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
  *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
  * </ul>
@@ -70,7 +70,7 @@ import java.util.NoSuchElementException;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class BinaryHeapDouble<E> implements PriorityQueue.Double<E>, Iterable<PriorityQueueNode.Double<E>> {
+public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 	
 	private PriorityQueueNode.Double<E>[] buffer;
 	private int size;
@@ -322,12 +322,12 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E>, Iterable<Pr
 	}
 	
 	@Override
-	public final E peek() {
+	public final E peekElement() {
 		return size > 0 ? buffer[0].element : null;
 	}
 	
 	@Override
-	public final PriorityQueueNode.Double<E> peekPair() {
+	public final PriorityQueueNode.Double<E> peek() {
 		return size > 0 ? buffer[0] : null;
 	}
 	
@@ -343,13 +343,13 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E>, Iterable<Pr
 	}
 	
 	@Override
-	public final E poll() {
-		PriorityQueueNode.Double<E> min = pollPair();
+	public final E pollElement() {
+		PriorityQueueNode.Double<E> min = poll();
 		return min != null ? min.element : null;
 	}
 	
 	@Override
-	public final PriorityQueueNode.Double<E> pollPair() {
+	public final PriorityQueueNode.Double<E> poll() {
 		if (size > 0) {
 			PriorityQueueNode.Double<E> min = buffer[0];
 			index.remove(min.element);

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -411,7 +411,7 @@ public class BinaryHeapDouble<E> implements PriorityQueueDouble<E> {
 		}
 		boolean changed = false;
 		for (E e : deleteThese) {
-changed = remove(e) || changed;
+			changed = remove(e) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -63,7 +63,8 @@ import java.util.NoSuchElementException;
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, double)}, {@link #offer(PriorityQueueNode.Double)},
  *     {@link #poll}, {@link #pollElement}, {@link #remove(Object)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
- *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
+ *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #toArray()}, {@link #toArray(Object[])}, 
+ *     {@link #trimToSize}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the BinaryHeap.
@@ -71,7 +72,7 @@ import java.util.NoSuchElementException;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
+public class BinaryHeapDouble<E> implements PriorityQueueDouble<E> {
 	
 	private PriorityQueueNode.Double<E>[] buffer;
 	private int size;

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -22,6 +22,7 @@
  
 package org.cicirello.ds;
 
+import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Arrays;
@@ -395,6 +396,30 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 	@Override
 	public final int size() {
 		return size;
+	}
+	
+	@Override
+	public final Object[] toArray() {
+		Object[] array = new Object[size];
+		for (int i = 0; i < size; i++) {
+			array[i] = buffer[i];
+		}
+		return array;
+	}
+	
+	@Override
+	public final <T> T[] toArray(T[] array) {
+		@SuppressWarnings("unchecked")
+		T[] result = array.length >= size ? array : (T[])Array.newInstance(array.getClass().getComponentType(), size);
+		for (int i = 0; i < size; i++) {
+			@SuppressWarnings("unchecked")
+			T nextElement = (T)buffer[i];
+			result[i] = nextElement;
+		}
+		if (result.length > size) {
+			result[size] = null;
+		}
+		return result;
 	}
 	
 	/**

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -60,7 +60,7 @@ import java.util.NoSuchElementException;
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(Object)},
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #change}, {@link #offer(Object, double)}, {@link #offer(PriorityQueueNode.Double)},
- *     {@link #poll}, {@link #pollElement}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #remove(Object)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)},
  *     {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, {@link #trimToSize}</li>
  * </ul>

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -293,13 +293,6 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 		return size == 0;
 	}
 	
-	/**
-	 * Returns an iterator over the (element, priority) pairs in a
-	 * mostly arbitrary order (i.e., you must not assume any particular
-	 * order).
-	 *
-	 * @return an iterator over the (element, priority) pairs
-	 */
 	@Override
 	public final Iterator<PriorityQueueNode.Double<E>> iterator() {
 		return new BinaryHeapDoubleIterator();

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -227,8 +227,12 @@ public class BinaryHeapDouble<E> implements PriorityQueue.Double<E> {
 	}
 	
 	@Override
-	public final boolean contains(E element) {
-		return index.containsKey(element);
+	public final boolean contains(Object o) {
+		if (o instanceof PriorityQueueNode.Double) {
+			PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+			return index.containsKey(pair.element);
+		}
+		return index.containsKey(o);
 	}
 	
 	/**

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -411,7 +411,7 @@ public class BinaryHeapDouble<E> implements PriorityQueueDouble<E> {
 		}
 		boolean changed = false;
 		for (E e : deleteThese) {
-			changed = remove(e) | changed;
+changed = remove(e) || changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -312,7 +312,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-			changed = remove(o) | changed;
+changed = remove(o) || changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -101,7 +101,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Integer<E> e : c) {
-			changed = changed | add(e);
+			changed = add(e) | changed;
 		}
 		return changed;
 	}
@@ -312,7 +312,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-			changed = changed || remove(o);
+			changed = remove(o) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -101,7 +101,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Integer<E> e : c) {
-			changed = add(e) | changed;
+changed = add(e) || changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -22,6 +22,7 @@
  
 package org.cicirello.ds;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -58,6 +59,23 @@ public interface PriorityQueue<E> {
 	 * @return true if and only if this PriorityQueue contains the element.
 	 */
 	boolean contains(Object o);
+	
+	/**
+	 * Checks if this PriorityQueue contains all elements
+	 * or (element, priority) pairs from a given Collection.
+	 *
+	 * @param c A Collection of elements or (element, priority) pairs to check
+	 *    for containment.
+	 *
+	 * @return true if and only if this PriorityQueue contains all of the elements
+	 * or (element, priority) pairs in c.
+	 */
+	default boolean containsAll(Collection<?> c) {
+		for (Object o : c) {
+			if (!contains(o)) return false;
+		}
+		return true;
+	}
 	
 	/**
 	 * Checks if the PriorityQueue is empty.

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -147,6 +147,19 @@ public interface PriorityQueue<E> {
 	}
 	
 	/**
+	 * This PriorityQueue does not support the optional {@link Collection#retainAll} method.
+	 * 
+	 * @param c a Collection
+	 *
+	 * @return this method is not supported
+	 *
+	 * @throws UnsupportedOperationException on all calls
+	 */
+	default boolean retainAll(Collection<?> c) {
+		throw new UnsupportedOperationException("retainAll is not supported by this PriorityQueue");
+	}
+	
+	/**
 	 * Gets the current size of the PriorityQueue, which is the
 	 * number of (element, value) pairs that it contains.
 	 *
@@ -154,6 +167,40 @@ public interface PriorityQueue<E> {
 	 */
 	int size();
 	
+	/**
+	 * Returns an array containing all of the (element, priority) pairs contained in the
+	 * PriorityQueue. The order is not guaranteed. The runtime component type is Object.
+	 * The PriorityQueue does not maintain any references to the array that is returned,
+	 * instead creating a new array upon each call to the toArray method. The length of the
+	 * array that is returned is equal to the current {@link #size()} of the PriorityQueue.
+	 *
+	 * @return an array, whose runtime component type is Object, containing all of the 
+	 * (element, priority) pairs currently in the PriorityQueue.
+	 */
+	Object[] toArray();
+	
+	/**
+	 * Returns an array containing all of the (element, priority) pairs contained in the
+	 * PriorityQueue. The order is not guaranteed. The runtime component type is the same
+	 * as the array passed to it as a parameter. If the specified array is large enough,
+	 * then it is used, otherwise a new array is allocated whose length is equal to 
+	 * the current {@link #size()} of the PriorityQueue. If the specified array is larger
+	 * than the current size() of the PriorityQueue, the first extra cell is set to null.
+	 *
+	 * @param array The array in which to place the (element, priority) pairs, if it is
+	 * sufficiently large, otherwise a new array of length {@link #size()} is allocated of
+	 * the same runtime type as array.
+	 *
+	 * @param <T> The component type of the array to contain the (element, priority) pairs
+	 *
+	 * @return The array in which the (element, priority) pairs have been inserted.
+	 *
+	 * @throws ArrayStoreException if the runtime component type of array is not
+	 * compatible with the type of the (element, priority) pairs.
+	 *
+	 * @throws NullPointerException if array is null
+	 */
+	<T> T[] toArray(T[] array);
 	
 	/**
 	 * <p>Interface common to the classes that provide implementations of
@@ -209,6 +256,27 @@ public interface PriorityQueue<E> {
 				throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
 			}
 			return true;
+		}
+		
+		/**
+		 * Adds all (element, priority) pairs from a Collection to the PriorityQueue,
+		 * provided the elements are not already in the PriorityQueue.
+		 * The default implementation calls the {@link #add(PriorityQueueNode.Integer)} 
+		 * for each pair in the Collection. 
+		 *
+		 * @param c the Collection of (element, priority) pairs to add.
+		 *
+		 * @return true if the (element, priority) pairs were added.
+		 *
+		 * @throws IllegalArgumentException if the PriorityQueue already contains any
+		 * of the (element, priority) pairs.
+		 */
+		default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
+			boolean changed = false;
+			for (PriorityQueueNode.Integer<E> e : c) {
+				changed = changed | add(e);
+			}
+			return changed;
 		}
 		
 		/**

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -49,13 +49,15 @@ public interface PriorityQueue<E> {
 	void clear();
 	
 	/**
-	 * Checks if this PriorityQueue contains a given element.
+	 * Checks if this PriorityQueue contains a given element
+	 * or an (element, priority) pair with a given element.
 	 *
-	 * @param element The element to check.
+	 * @param o An element or (element, priority) pair to check
+	 *    for containment of the element.
 	 *
 	 * @return true if and only if this PriorityQueue contains the element.
 	 */
-	boolean contains(E element);
+	boolean contains(Object o);
 	
 	/**
 	 * Checks if the PriorityQueue is empty.

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -100,6 +100,19 @@ public interface PriorityQueue<E> {
 	E pollElement();
 	
 	/**
+	 * Removes from this PriorityQueue the (element, priority) pair, if present, 
+	 * for a specified element or element from a specified (element, priority) pair.
+	 *
+	 * @param o An element or (element, priority) pair, such that element designates
+	 * the desired pair to remove (note that if you pass an (element, priority) pair,
+	 * only the element must match to cause removal.
+	 *
+	 * @return true if and only if an (element, priority) pair was removed as a result
+	 * of this method call.
+	 */
+	boolean remove(Object o);
+	
+	/**
 	 * Removes and returns the next element in priority order from this PriorityQueue.
 	 * This method differs from {@link #pollElement()} in that if the PriorityQueue is
 	 * empty, this method throws an exception, while {@link #pollElement()} returns null.

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -113,6 +113,23 @@ public interface PriorityQueue<E> {
 	boolean remove(Object o);
 	
 	/**
+	 * Removes from this PriorityQueue all (element, priority) pairs
+	 * such that a given Collection c either contains the element or
+	 * contains an (element, priority) pair with the same element.
+	 *
+	 * @param c A Collection of elements or (element, priority) pairs for removal.
+	 *
+	 * @return true if and only if this PriorityQueue changed as a result of this method.
+	 */
+	default boolean removeAll(Collection<?> c) {
+		boolean changed = false;
+		for (Object o : c) {
+			changed = changed || remove(o);
+		}
+		return changed;
+	}
+	
+	/**
 	 * Removes and returns the next element in priority order from this PriorityQueue.
 	 * This method differs from {@link #pollElement()} in that if the PriorityQueue is
 	 * empty, this method throws an exception, while {@link #pollElement()} returns null.

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -335,18 +335,16 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	}
 	
 	/**
-	 * This PriorityQueue does not support the optional {@link Collection#retainAll} method.
-	 * 
-	 * @param c a Collection
+	 * Removes from this PriorityQueue all (element, priority) pairs
+	 * except for the elements or (element, priority) pairs contained in a 
+	 * given Collection c.
 	 *
-	 * @return this method is not supported
+	 * @param c A Collection of elements or (element, priority) pairs to keep.
 	 *
-	 * @throws UnsupportedOperationException on all calls
+	 * @return true if and only if this PriorityQueue changed as a result of this method.
 	 */
 	@Override
-	default boolean retainAll(Collection<?> c) {
-		throw new UnsupportedOperationException("retainAll is not supported by this PriorityQueue");
-	}
+	boolean retainAll(Collection<?> c);
 	
 	/**
 	 * Gets the current size of the PriorityQueue, which is the

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -22,6 +22,9 @@
  
 package org.cicirello.ds;
 
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
 /**
  * <p>Interface common to the classes that provide implementations of
  * a priority queue. All PriorityQueue implementations enforce distinct
@@ -77,6 +80,23 @@ public interface PriorityQueue<E> {
 	E pollElement();
 	
 	/**
+	 * Removes and returns the next element in priority order from this PriorityQueue.
+	 * This method differs from {@link #pollElement()} in that if the PriorityQueue is
+	 * empty, this method throws an exception, while {@link #pollElement()} returns null.
+	 *
+	 * @return the next element in priority order.
+	 *
+	 * @throws NoSuchElementException if the PriorityQueue is empty
+	 */
+	default E removeElement() {
+		E result = pollElement();
+		if (result == null) {
+			throw new NoSuchElementException("PriorityQueue is empty");
+		}
+		return result;
+	}
+	
+	/**
 	 * Gets the current size of the PriorityQueue, which is the
 	 * number of (element, value) pairs that it contains.
 	 *
@@ -101,6 +121,47 @@ public interface PriorityQueue<E> {
 	public static interface Integer<E> extends PriorityQueue<E>, Iterable<PriorityQueueNode.Integer<E>> {
 		
 		/**
+		 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
+		 * provided the element is not already in the PriorityQueue.
+		 * This method differs from {@link #offer(Object, int)}
+		 * in that it throws an exception if the PriorityQueue contains the element,
+		 * while the offer method instead returns false.
+		 *
+		 * @param element The element.
+		 * @param priority The priority of the element.
+		 *
+		 * @return true if the (element, priority) pair was added.
+		 *
+		 * @throws IllegalArgumentException if the priority queue already contains the element.
+		 */
+		default boolean add(E element, int priority) {
+			if (!offer(element, priority)) {
+				throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
+			}
+			return true;
+		}
+		
+		/**
+		 * Adds an (element, priority) pair to the PriorityQueue,
+		 * provided the element is not already in the PriorityQueue.
+		 * This method differs from {@link #offer(PriorityQueueNode.Integer)}
+		 * in that it throws an exception if the PriorityQueue contains the element,
+		 * while the offer method instead returns false.
+		 *
+		 * @param pair The (element, priority) pair to add.
+		 *
+		 * @return true if the (element, priority) pair was added.
+		 *
+		 * @throws IllegalArgumentException if the priority queue already contains the element.
+		 */
+		default boolean add(PriorityQueueNode.Integer<E> pair) {
+			if (!offer(pair)) {
+				throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
+			}
+			return true;
+		}
+		
+		/**
 		 * Changes the priority of an element if the element is
 		 * present in the PriorityQueue, and otherwise adds the
 		 * (element, priority) pair to the PriorityQueue.
@@ -109,6 +170,38 @@ public interface PriorityQueue<E> {
 		 * @param priority Its new priority.
 		 */
 		void change(E element, int priority);
+		
+		/**
+		 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueue,
+		 * without removing it.</p>
+		 * <p>This method differs from {@link #peek()} in that if the PriorityQueue is
+		 * empty, this method throws an exception, while {@link #peek()} returns null.</p>
+		 * <p>This method serves a different purpose than {@link peekElement()}. The
+		 * {@link peekElement()} methods returns only the element of the (element, priority)
+		 * pair, while this method returns the (element, priority) pair. This element() method
+		 * is included only for full implementation of the superinterface {@link java.util.Queue Queue}.</p>
+		 *
+		 * @return the next (element, priority) pair in priority order.
+		 *
+		 * @throws NoSuchElementException if the PriorityQueue is empty
+		 */
+		default PriorityQueueNode.Integer<E> element() {
+			PriorityQueueNode.Integer<E> result = peek();
+			if (result == null) {
+				throw new NoSuchElementException("PriorityQueue is empty");
+			}
+			return result;
+		}
+		
+		/**
+		 * Returns an iterator over the (element, priority) pairs in a
+		 * mostly arbitrary order (i.e., you must not assume any particular
+		 * order).
+		 *
+		 * @return an iterator over the (element, priority) pairs
+		 */
+		@Override
+		Iterator<PriorityQueueNode.Integer<E>> iterator();
 		
 		/**
 		 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
@@ -165,6 +258,23 @@ public interface PriorityQueue<E> {
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
 		PriorityQueueNode.Integer<E> poll();
+		
+		/**
+		 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue.
+		 * This method differs from {@link #poll()} in that if the PriorityQueue is
+		 * empty, this method throws an exception, while {@link #poll()} returns null.
+		 *
+		 * @return the next (element, priority) pair in priority order.
+		 *
+		 * @throws NoSuchElementException if the PriorityQueue is empty
+		 */
+		default PriorityQueueNode.Integer<E> remove() {
+			PriorityQueueNode.Integer<E> result = poll();
+			if (result == null) {
+				throw new NoSuchElementException("PriorityQueue is empty");
+			}
+			return result;
+		}
 	}
 	
 	/**
@@ -183,6 +293,47 @@ public interface PriorityQueue<E> {
 	public static interface Double<E> extends PriorityQueue<E>, Iterable<PriorityQueueNode.Double<E>> {
 		
 		/**
+		 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
+		 * provided the element is not already in the PriorityQueue.
+		 * This method differs from {@link #offer(Object, double)}
+		 * in that it throws an exception if the PriorityQueue contains the element,
+		 * while the offer method instead returns false.
+		 *
+		 * @param element The element.
+		 * @param priority The priority of the element.
+		 *
+		 * @return true if the (element, priority) pair was added.
+		 *
+		 * @throws IllegalArgumentException if the priority queue already contains the element.
+		 */
+		default boolean add(E element, double priority) {
+			if (!offer(element, priority)) {
+				throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
+			}
+			return true;
+		}
+		
+		/**
+		 * Adds an (element, priority) pair to the PriorityQueue,
+		 * provided the element is not already in the PriorityQueue.
+		 * This method differs from {@link #offer(PriorityQueueNode.Double)}
+		 * in that it throws an exception if the PriorityQueue contains the element,
+		 * while the offer method instead returns false.
+		 *
+		 * @param pair The (element, priority) pair to add.
+		 *
+		 * @return true if the (element, priority) pair was added.
+		 *
+		 * @throws IllegalArgumentException if the priority queue already contains the element.
+		 */
+		default boolean add(PriorityQueueNode.Double<E> pair) {
+			if (!offer(pair)) {
+				throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
+			}
+			return true;
+		}
+		
+		/**
 		 * Changes the priority of an element if the element is
 		 * present in the PriorityQueue, and otherwise adds the
 		 * (element, priority) pair to the PriorityQueue.
@@ -191,6 +342,38 @@ public interface PriorityQueue<E> {
 		 * @param priority Its new priority.
 		 */
 		void change(E element, double priority);
+		
+		/**
+		 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueue,
+		 * without removing it.</p>
+		 * <p>This method differs from {@link #peek()} in that if the PriorityQueue is
+		 * empty, this method throws an exception, while {@link #peek()} returns null.</p>
+		 * <p>This method serves a different purpose than {@link peekElement()}. The
+		 * {@link peekElement()} methods returns only the element of the (element, priority)
+		 * pair, while this method returns the (element, priority) pair. This element() method
+		 * is included only for full implementation of the superinterface {@link java.util.Queue Queue}.</p>
+		 *
+		 * @return the next (element, priority) pair in priority order.
+		 *
+		 * @throws NoSuchElementException if the PriorityQueue is empty
+		 */
+		default PriorityQueueNode.Double<E> element() {
+			PriorityQueueNode.Double<E> result = peek();
+			if (result == null) {
+				throw new NoSuchElementException("PriorityQueue is empty");
+			}
+			return result;
+		}
+		
+		/**
+		 * Returns an iterator over the (element, priority) pairs in a
+		 * mostly arbitrary order (i.e., you must not assume any particular
+		 * order).
+		 *
+		 * @return an iterator over the (element, priority) pairs
+		 */
+		@Override
+		Iterator<PriorityQueueNode.Double<E>> iterator();
 		
 		/**
 		 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
@@ -247,5 +430,22 @@ public interface PriorityQueue<E> {
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
 		PriorityQueueNode.Double<E> poll();
+		
+		/**
+		 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue.
+		 * This method differs from {@link #poll()} in that if the PriorityQueue is
+		 * empty, this method throws an exception, while {@link #poll()} returns null.
+		 *
+		 * @return the next (element, priority) pair in priority order.
+		 *
+		 * @throws NoSuchElementException if the PriorityQueue is empty
+		 */
+		default PriorityQueueNode.Double<E> remove() {
+			PriorityQueueNode.Double<E> result = poll();
+			if (result == null) {
+				throw new NoSuchElementException("PriorityQueue is empty");
+			}
+			return result;
+		}
 	}
 }

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -101,7 +101,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Integer<E> e : c) {
-changed = add(e) || changed;
+			changed = add(e) | changed;
 		}
 		return changed;
 	}
@@ -312,7 +312,7 @@ changed = add(e) || changed;
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-changed = remove(o) || changed;
+			changed = remove(o) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -67,14 +67,14 @@ public interface PriorityQueue<E> {
 	 *
 	 * @return the next element in priority order, or null if empty.
 	 */
-	E peek();
+	E peekElement();
 	
 	/**
 	 * Removes and returns the next element in priority order from this PriorityQueue.
 	 *
 	 * @return the next element in priority order, or null if empty.
 	 */
-	E poll();
+	E pollElement();
 	
 	/**
 	 * Gets the current size of the PriorityQueue, which is the
@@ -98,7 +98,7 @@ public interface PriorityQueue<E> {
 	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
 	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
 	 */
-	public static interface Integer<E> extends PriorityQueue<E> {
+	public static interface Integer<E> extends PriorityQueue<E>, Iterable<PriorityQueueNode.Integer<E>> {
 		
 		/**
 		 * Changes the priority of an element if the element is
@@ -139,7 +139,7 @@ public interface PriorityQueue<E> {
 		 *
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
-		PriorityQueueNode.Integer<E> peekPair();
+		PriorityQueueNode.Integer<E> peek();
 		
 		/**
 		 * Gets the priority of the next element in priority order in the PriorityQueue.
@@ -164,7 +164,7 @@ public interface PriorityQueue<E> {
 		 *
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
-		PriorityQueueNode.Integer<E> pollPair();
+		PriorityQueueNode.Integer<E> poll();
 	}
 	
 	/**
@@ -180,7 +180,7 @@ public interface PriorityQueue<E> {
 	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
 	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
 	 */
-	public static interface Double<E> extends PriorityQueue<E> {
+	public static interface Double<E> extends PriorityQueue<E>, Iterable<PriorityQueueNode.Double<E>> {
 		
 		/**
 		 * Changes the priority of an element if the element is
@@ -221,7 +221,7 @@ public interface PriorityQueue<E> {
 		 *
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
-		PriorityQueueNode.Double<E> peekPair();
+		PriorityQueueNode.Double<E> peek();
 		
 		/**
 		 * Gets the priority of the next element in priority order in the PriorityQueue.
@@ -246,6 +246,6 @@ public interface PriorityQueue<E> {
 		 *
 		 * @return the next (element, priority) pair in priority order, or null if empty.
 		 */
-		PriorityQueueNode.Double<E> pollPair();
+		PriorityQueueNode.Double<E> poll();
 	}
 }

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -29,7 +29,7 @@ import java.util.Queue;
 
 /**
  * <p>Interface common to the classes that provide implementations of
- * a priority queue with int valued priorities. All PriorityQueue 
+ * a priority queue with double valued priorities. All PriorityQueue 
  * implementations enforce distinct elements, and use the
  * {@link Object#hashCode} and {@link Object#equals} methods to
  * to enforce distinctness, so be sure that the class of the elements
@@ -40,12 +40,12 @@ import java.util.Queue;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
+public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E>> {
 	
 	/**
 	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
 	 * provided the element is not already in the PriorityQueue.
-	 * This method differs from {@link #offer(Object, int)}
+	 * This method differs from {@link #offer(Object, double)}
 	 * in that it throws an exception if the PriorityQueue contains the element,
 	 * while the offer method instead returns false.
 	 *
@@ -56,7 +56,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 *
 	 * @throws IllegalArgumentException if the priority queue already contains the element.
 	 */
-	default boolean add(E element, int priority) {
+	default boolean add(E element, double priority) {
 		if (!offer(element, priority)) {
 			throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
 		}
@@ -66,7 +66,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	/**
 	 * Adds an (element, priority) pair to the PriorityQueue,
 	 * provided the element is not already in the PriorityQueue.
-	 * This method differs from {@link #offer(PriorityQueueNode.Integer)}
+	 * This method differs from {@link #offer(PriorityQueueNode.Double)}
 	 * in that it throws an exception if the PriorityQueue contains the element,
 	 * while the offer method instead returns false.
 	 *
@@ -77,7 +77,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @throws IllegalArgumentException if the priority queue already contains the element.
 	 */
 	@Override
-	default boolean add(PriorityQueueNode.Integer<E> pair) {
+	default boolean add(PriorityQueueNode.Double<E> pair) {
 		if (!offer(pair)) {
 			throw new IllegalArgumentException("already contains an (element, priority) pair with this element");
 		}
@@ -87,7 +87,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	/**
 	 * Adds all (element, priority) pairs from a Collection to the PriorityQueue,
 	 * provided the elements are not already in the PriorityQueue.
-	 * The default implementation calls the {@link #add(PriorityQueueNode.Integer)} 
+	 * The default implementation calls the {@link #add(PriorityQueueNode.Double)} 
 	 * for each pair in the Collection. 
 	 *
 	 * @param c the Collection of (element, priority) pairs to add.
@@ -98,9 +98,9 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * of the (element, priority) pairs.
 	 */
 	@Override
-	default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
+	default boolean addAll(Collection<? extends PriorityQueueNode.Double<E>> c) {
 		boolean changed = false;
-		for (PriorityQueueNode.Integer<E> e : c) {
+		for (PriorityQueueNode.Double<E> e : c) {
 			changed = changed | add(e);
 		}
 		return changed;
@@ -114,7 +114,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @param element The element whose priority is to change.
 	 * @param priority Its new priority.
 	 */
-	void change(E element, int priority);
+	void change(E element, double priority);
 	
 	/**
 	 * Clears the PriorityQueue, removing all elements.
@@ -167,8 +167,8 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @throws NoSuchElementException if the PriorityQueue is empty
 	 */
 	@Override
-	default PriorityQueueNode.Integer<E> element() {
-		PriorityQueueNode.Integer<E> result = peek();
+	default PriorityQueueNode.Double<E> element() {
+		PriorityQueueNode.Double<E> result = peek();
 		if (result == null) {
 			throw new NoSuchElementException("PriorityQueue is empty");
 		}
@@ -191,7 +191,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @return an iterator over the (element, priority) pairs
 	 */
 	@Override
-	Iterator<PriorityQueueNode.Integer<E>> iterator();
+	Iterator<PriorityQueueNode.Double<E>> iterator();
 	
 	/**
 	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
@@ -203,7 +203,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @return true if the (element, priority) pair was added, and false if the
 	 * PriorityQueue already contained the element.
 	 */
-	boolean offer(E element, int priority);
+	boolean offer(E element, double priority);
 	
 	/**
 	 * Adds an (element, priority) pair to the PriorityQueue,
@@ -215,7 +215,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * PriorityQueue already contained the element.
 	 */
 	@Override
-	boolean offer(PriorityQueueNode.Integer<E> pair);
+	boolean offer(PriorityQueueNode.Double<E> pair);
 	
 	/**
 	 * Gets the next (element, priority) pair in priority order from this PriorityQueue,
@@ -224,14 +224,14 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @return the next (element, priority) pair in priority order, or null if empty.
 	 */
 	@Override
-	PriorityQueueNode.Integer<E> peek();
+	PriorityQueueNode.Double<E> peek();
 	
 	/**
 	 * Gets the priority of the next element in priority order in the PriorityQueue.
 	 *
 	 * @return the priority of the next element in priority order.
 	 */
-	int peekPriority();
+	double peekPriority();
 	
 	/**
 	 * Gets the priority of a specified element if it is present in the PriorityQueue.
@@ -242,7 +242,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 *
 	 * @return the priority of a specified element.
 	 */
-	int peekPriority(E element);
+	double peekPriority(E element);
 	
 	/**
 	 * Gets the next element in priority order from this PriorityQueue,
@@ -258,7 +258,7 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @return the next (element, priority) pair in priority order, or null if empty.
 	 */
 	@Override
-	PriorityQueueNode.Integer<E> poll();
+	PriorityQueueNode.Double<E> poll();
 	
 	/**
 	 * Removes and returns the next element in priority order from this PriorityQueue.
@@ -277,8 +277,8 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @throws NoSuchElementException if the PriorityQueue is empty
 	 */
 	@Override
-	default PriorityQueueNode.Integer<E> remove() {
-		PriorityQueueNode.Integer<E> result = poll();
+	default PriorityQueueNode.Double<E> remove() {
+		PriorityQueueNode.Double<E> result = poll();
 		if (result == null) {
 			throw new NoSuchElementException("PriorityQueue is empty");
 		}

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -101,7 +101,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	default boolean addAll(Collection<? extends PriorityQueueNode.Double<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Double<E> e : c) {
-changed = add(e) || changed;
+			changed = add(e) | changed;
 		}
 		return changed;
 	}
@@ -312,7 +312,7 @@ changed = add(e) || changed;
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-changed = remove(o) || changed;
+			changed = remove(o) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -101,7 +101,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	default boolean addAll(Collection<? extends PriorityQueueNode.Double<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Double<E> e : c) {
-			changed = changed | add(e);
+			changed = add(e) | changed;
 		}
 		return changed;
 	}
@@ -312,7 +312,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-			changed = changed || remove(o);
+			changed = remove(o) | changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -101,7 +101,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	default boolean addAll(Collection<? extends PriorityQueueNode.Double<E>> c) {
 		boolean changed = false;
 		for (PriorityQueueNode.Double<E> e : c) {
-			changed = add(e) | changed;
+changed = add(e) || changed;
 		}
 		return changed;
 	}

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -335,18 +335,16 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * This PriorityQueue does not support the optional {@link Collection#retainAll} method.
-	 * 
-	 * @param c a Collection
+	 * Removes from this PriorityQueue all (element, priority) pairs
+	 * except for the elements or (element, priority) pairs contained in a 
+	 * given Collection c.
 	 *
-	 * @return this method is not supported
+	 * @param c A Collection of elements or (element, priority) pairs to keep.
 	 *
-	 * @throws UnsupportedOperationException on all calls
+	 * @return true if and only if this PriorityQueue changed as a result of this method.
 	 */
 	@Override
-	default boolean retainAll(Collection<?> c) {
-		throw new UnsupportedOperationException("retainAll is not supported by this PriorityQueue");
-	}
+	boolean retainAll(Collection<?> c);
 	
 	/**
 	 * Gets the current size of the PriorityQueue, which is the

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -312,7 +312,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	default boolean removeAll(Collection<?> c) {
 		boolean changed = false;
 		for (Object o : c) {
-			changed = remove(o) | changed;
+changed = remove(o) || changed;
 		}
 		return changed;
 	}

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -321,6 +321,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -361,6 +362,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -398,6 +400,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -432,6 +435,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -477,6 +481,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -510,6 +515,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -551,6 +557,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -596,6 +603,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -633,6 +641,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -786,6 +795,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -826,6 +836,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -863,6 +874,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -897,6 +909,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -942,6 +955,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -975,6 +989,7 @@ public class BinaryHeapDoubleTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1016,6 +1031,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1061,6 +1077,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1098,6 +1115,7 @@ public class BinaryHeapDoubleTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -46,8 +46,16 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 		}
 		assertEquals(elements.length, pq.size());
-		String[] retain = {"A", "E", "C", "F"};
+		String[] retain = {"E", "A", "F", "C"};
 		ArrayList<Object> keepThese = new ArrayList<Object>();
+		keepThese.add(elements[0]);
+		keepThese.add(elements[1]);
+		keepThese.add(elements[2]);
+		keepThese.add(elements[3]);
+		assertFalse(pq.retainAll(keepThese));
+		assertEquals(elements.length, pq.size());
+		
+		keepThese.clear();
 		keepThese.add(retain[0]);
 		keepThese.add(retain[1]);
 		keepThese.add(new PriorityQueueNode.Double<String>(retain[2], 5));
@@ -58,6 +66,18 @@ public class BinaryHeapDoubleTests {
 		assertTrue(pq.contains(elements[2]));
 		assertFalse(pq.contains(elements[1]));
 		assertFalse(pq.contains(elements[3]));
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[1]);
+		keepThese.add(retain[3]);
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[2]);
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(0, pq.size());
 	}
 	
 	@Test

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -106,11 +106,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(n, pq.capacity());
 		assertEquals(n, pq.size());
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		assertEquals(n, pq.capacity());
 		assertEquals(0, pq.size());
 	}
@@ -206,10 +206,10 @@ public class BinaryHeapDoubleTests {
 			}
 			pq.change(elements[i], 1);
 			assertEquals(1.0, pq.peekPriority(elements[i]), 0.0);
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -224,10 +224,10 @@ public class BinaryHeapDoubleTests {
 			assertEquals(100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertTrue(pq.isEmpty());
 		}
 		// to interior tests
@@ -244,16 +244,16 @@ public class BinaryHeapDoubleTests {
 				for (; j < n; j++) {
 					if (i != j) {
 						if (priorities[j] < p) {
-							assertEquals(elements[j], pq.poll(), "p,i,j="+p+","+i+","+j);
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 						} else {
 							break;
 						}
 					}
 				}
-				assertEquals(elements[i], pq.poll(), "p,i,j="+p+","+i+","+j);
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 				for (; j < n; j++) {
 					if (i!=j && priorities[j] > p) {
-						assertEquals(elements[j], pq.poll());
+						assertEquals(elements[j], pq.pollElement());
 					}
 				}
 				assertTrue(pq.isEmpty());
@@ -268,7 +268,7 @@ public class BinaryHeapDoubleTests {
 			pq.change(elements[i], priorities[i]);
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
-				assertEquals(elements[j], pq.poll());
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}
@@ -284,15 +284,15 @@ public class BinaryHeapDoubleTests {
 			int j = 0;
 			for (; j < n; j++) {
 				if (priorities[j] < p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				} else {
 					break;
 				}
 			}
-			assertEquals("YYY", pq.poll());
+			assertEquals("YYY", pq.pollElement());
 			for (; j < n; j++) {
 				if (priorities[j] > p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -308,23 +308,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -332,11 +332,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -348,23 +348,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -372,11 +372,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -388,8 +388,8 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
@@ -400,8 +400,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -410,11 +410,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -434,8 +434,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -443,11 +443,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -479,8 +479,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -488,11 +488,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -512,8 +512,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -522,11 +522,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -538,23 +538,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -562,11 +562,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -583,23 +583,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -607,11 +607,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[n-1-i], pq.poll());
+			assertEquals(elements[n-1-i], pq.pollElement());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	@Test
@@ -623,8 +623,8 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
@@ -635,8 +635,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -645,11 +645,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(expected, pq.poll());
+			assertEquals(expected, pq.pollElement());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	
@@ -671,10 +671,10 @@ public class BinaryHeapDoubleTests {
 			}
 			pq.change(elements[i], -1);
 			assertEquals(-1.0, pq.peekPriority(elements[i]), 0.0);
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -689,10 +689,10 @@ public class BinaryHeapDoubleTests {
 			assertEquals(-100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertTrue(pq.isEmpty());
 		}
 		// to interior tests
@@ -709,16 +709,16 @@ public class BinaryHeapDoubleTests {
 				for (; j < n; j++) {
 					if (i != j) {
 						if (priorities[j] > -p) {
-							assertEquals(elements[j], pq.poll(), "p,i,j="+p+","+i+","+j);
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 						} else {
 							break;
 						}
 					}
 				}
-				assertEquals(elements[i], pq.poll(), "p,i,j="+p+","+i+","+j);
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 				for (; j < n; j++) {
 					if (i!=j && priorities[j] < -p) {
-						assertEquals(elements[j], pq.poll());
+						assertEquals(elements[j], pq.pollElement());
 					}
 				}
 				assertTrue(pq.isEmpty());
@@ -733,7 +733,7 @@ public class BinaryHeapDoubleTests {
 			pq.change(elements[i], priorities[i]);
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
-				assertEquals(elements[j], pq.poll());
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}
@@ -749,15 +749,15 @@ public class BinaryHeapDoubleTests {
 			int j = 0;
 			for (; j < n; j++) {
 				if (priorities[j] > -p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				} else {
 					break;
 				}
 			}
-			assertEquals("YYY", pq.poll());
+			assertEquals("YYY", pq.pollElement());
 			for (; j < n; j++) {
 				if (priorities[j] < -p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -773,23 +773,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -797,11 +797,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -813,23 +813,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -837,11 +837,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -853,8 +853,8 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
@@ -865,8 +865,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -875,11 +875,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -899,8 +899,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -908,11 +908,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -944,8 +944,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -953,11 +953,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -977,8 +977,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -987,11 +987,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -1003,23 +1003,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -1027,11 +1027,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -1048,23 +1048,23 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -1072,11 +1072,11 @@ public class BinaryHeapDoubleTests {
 		}
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[n-1-i], pq.poll());
+			assertEquals(elements[n-1-i], pq.pollElement());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	@Test
@@ -1088,8 +1088,8 @@ public class BinaryHeapDoubleTests {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
@@ -1100,8 +1100,8 @@ public class BinaryHeapDoubleTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
 			assertEquals((double)'A', pq.peekPriority(), 0.0);
 		}
 		for (int i = 0; i < n; i++) {
@@ -1110,11 +1110,11 @@ public class BinaryHeapDoubleTests {
 		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(expected, pq.poll());
+			assertEquals(expected, pq.pollElement());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -191,6 +191,146 @@ public class BinaryHeapDoubleTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testRemoveMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = (2 + 2*i);
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			double[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			double[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
+	
+	@Test
 	public void testChangePriorityMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);
@@ -663,6 +803,146 @@ public class BinaryHeapDoubleTests {
 	
 	
 	// MAX HEAP TESTS
+	
+	@Test
+	public void testRemoveMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			double[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			double[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
 	
 	@Test
 	public void testChangePriorityMaxHeap() {

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -38,6 +38,29 @@ public class BinaryHeapDoubleTests {
 	// TESTS THAT ARE NEITHER STRICTLY MIN HEAP TESTS NOW MAX HEAP TESTS
 	
 	@Test
+	public void testRetainAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+		}
+		assertEquals(elements.length, pq.size());
+		String[] retain = {"A", "E", "C", "F"};
+		ArrayList<Object> keepThese = new ArrayList<Object>();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[1]);
+		keepThese.add(new PriorityQueueNode.Double<String>(retain[2], 5));
+		keepThese.add(new PriorityQueueNode.Double<String>(retain[3], 15));
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(elements.length-2, pq.size());
+		assertTrue(pq.contains(elements[0]));
+		assertTrue(pq.contains(elements[2]));
+		assertFalse(pq.contains(elements[1]));
+		assertFalse(pq.contains(elements[3]));
+	}
+	
+	@Test
 	public void testIterator() {
 		int n = 4;
 		String[] elements = createStrings(n);

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -67,6 +67,65 @@ public class BinaryHeapDoubleTests {
 	}
 	
 	@Test
+	public void testToArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		for (int m = 0; m < n; m++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			Object[] array = pq.toArray();
+			assertEquals(m, array.length);
+			int j = 0;
+			for (PriorityQueueNode.Double<String> e : pq) {
+				assertEquals(e, (PriorityQueueNode.Double)array[j]);
+				j++;
+			}
+		}
+	}
+	
+	@Test
+	public void testToArrayExistingArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		for (int m = 0; m <= n; m++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double[] a1 = new PriorityQueueNode.Double[n];
+			PriorityQueueNode.Double[] a2 = pq.toArray(a1);
+			assertTrue(a1 == a2);
+			int j = 0;
+			for (PriorityQueueNode.Double<String> e : pq) {
+				assertEquals(e, a2[j]);
+				j++;
+			}
+			assertEquals(m, j);
+			if (m<n) {
+				assertNull(a2[j]);
+			}
+		}
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		PriorityQueueNode.Double[] a1 = new PriorityQueueNode.Double[n-1];
+		PriorityQueueNode.Double[] a2 = pq.toArray(a1);
+		assertTrue(a1 != a2);
+		assertEquals(n, a2.length);
+		int j = 0;
+		for (PriorityQueueNode.Double<String> e : pq) {
+			assertEquals(e, a2[j]);
+			j++;
+		}
+		assertEquals(n, j);
+	}
+	
+	@Test
 	public void testCapacity() {
 		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
 		assertEquals(BinaryHeapDouble.DEFAULT_INITIAL_CAPACITY, pq.capacity());

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -67,6 +67,66 @@ public class BinaryHeapTests {
 	}
 	
 	@Test
+	public void testToArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		int[] priorities = createPriorities(elements);
+		for (int m = 0; m <= n; m++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			Object[] array = pq.toArray();
+			assertEquals(m, array.length);
+			int j = 0;
+			for (PriorityQueueNode.Integer<String> e : pq) {
+				assertEquals(e, (PriorityQueueNode.Integer)array[j]);
+				j++;
+			}
+			assertEquals(m, j);
+		}
+	}
+	
+	@Test
+	public void testToArrayExistingArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		int[] priorities = createPriorities(elements);
+		for (int m = 0; m <= n; m++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Integer[] a1 = new PriorityQueueNode.Integer[n];
+			PriorityQueueNode.Integer[] a2 = pq.toArray(a1);
+			assertTrue(a1 == a2);
+			int j = 0;
+			for (PriorityQueueNode.Integer<String> e : pq) {
+				assertEquals(e, a2[j]);
+				j++;
+			}
+			assertEquals(m, j);
+			if (m<n) {
+				assertNull(a2[j]);
+			}
+		}
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		PriorityQueueNode.Integer[] a1 = new PriorityQueueNode.Integer[n-1];
+		PriorityQueueNode.Integer[] a2 = pq.toArray(a1);
+		assertTrue(a1 != a2);
+		assertEquals(n, a2.length);
+		int j = 0;
+		for (PriorityQueueNode.Integer<String> e : pq) {
+			assertEquals(e, a2[j]);
+			j++;
+		}
+		assertEquals(n, j);
+	}
+	
+	@Test
 	public void testCapacity() {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
 		assertEquals(BinaryHeap.DEFAULT_INITIAL_CAPACITY, pq.capacity());

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -321,6 +321,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -361,6 +362,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -398,6 +400,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -432,6 +435,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -477,6 +481,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -510,6 +515,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -551,6 +557,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -596,6 +603,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -633,6 +641,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -786,6 +795,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -826,6 +836,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -863,6 +874,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -897,6 +909,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -942,6 +955,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -975,6 +989,7 @@ public class BinaryHeapTests {
 		assertFalse(pq.isEmpty());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1016,6 +1031,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1061,6 +1077,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());
@@ -1098,6 +1115,7 @@ public class BinaryHeapTests {
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
 			assertEquals("A", pq.peekElement());

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -38,6 +38,29 @@ public class BinaryHeapTests {
 	// TESTS THAT ARE NEITHER STRICTLY MIN HEAP TESTS NOW MAX HEAP TESTS
 	
 	@Test
+	public void testRetainAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+		}
+		assertEquals(elements.length, pq.size());
+		String[] retain = {"A", "E", "C", "F"};
+		ArrayList<Object> keepThese = new ArrayList<Object>();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[1]);
+		keepThese.add(new PriorityQueueNode.Integer<String>(retain[2], 5));
+		keepThese.add(new PriorityQueueNode.Integer<String>(retain[3], 15));
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(elements.length-2, pq.size());
+		assertTrue(pq.contains(elements[0]));
+		assertTrue(pq.contains(elements[2]));
+		assertFalse(pq.contains(elements[1]));
+		assertFalse(pq.contains(elements[3]));
+	}
+	
+	@Test
 	public void testIterator() {
 		int n = 4;
 		String[] elements = createStrings(n);

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -191,6 +191,146 @@ public class BinaryHeapTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testRemoveMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			int[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			int[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
+	
+	@Test
 	public void testChangePriorityMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);
@@ -663,6 +803,146 @@ public class BinaryHeapTests {
 	
 	
 	// MAX HEAP TESTS
+	
+	@Test
+	public void testRemoveMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			int[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			int[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Integer<String> pair = new PriorityQueueNode.Integer<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
 	
 	@Test
 	public void testChangePriorityMaxHeap() {

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -106,11 +106,11 @@ public class BinaryHeapTests {
 		assertEquals(n, pq.capacity());
 		assertEquals(n, pq.size());
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		assertEquals(n, pq.capacity());
 		assertEquals(0, pq.size());
 	}
@@ -206,10 +206,10 @@ public class BinaryHeapTests {
 			}
 			pq.change(elements[i], 1);
 			assertEquals(1, pq.peekPriority(elements[i]));
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -224,10 +224,10 @@ public class BinaryHeapTests {
 			assertEquals(100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertTrue(pq.isEmpty());
 		}
 		// to interior tests
@@ -244,16 +244,16 @@ public class BinaryHeapTests {
 				for (; j < n; j++) {
 					if (i != j) {
 						if (priorities[j] < p) {
-							assertEquals(elements[j], pq.poll(), "p,i,j="+p+","+i+","+j);
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 						} else {
 							break;
 						}
 					}
 				}
-				assertEquals(elements[i], pq.poll(), "p,i,j="+p+","+i+","+j);
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 				for (; j < n; j++) {
 					if (i!=j && priorities[j] > p) {
-						assertEquals(elements[j], pq.poll());
+						assertEquals(elements[j], pq.pollElement());
 					}
 				}
 				assertTrue(pq.isEmpty());
@@ -268,7 +268,7 @@ public class BinaryHeapTests {
 			pq.change(elements[i], priorities[i]);
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
-				assertEquals(elements[j], pq.poll());
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}
@@ -284,15 +284,15 @@ public class BinaryHeapTests {
 			int j = 0;
 			for (; j < n; j++) {
 				if (priorities[j] < p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				} else {
 					break;
 				}
 			}
-			assertEquals("YYY", pq.poll());
+			assertEquals("YYY", pq.pollElement());
 			for (; j < n; j++) {
 				if (priorities[j] > p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -308,23 +308,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -332,11 +332,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -348,23 +348,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((int)elements[i].charAt(0), pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -372,11 +372,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -388,8 +388,8 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
@@ -400,8 +400,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -410,11 +410,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'+i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'+i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -434,8 +434,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -443,11 +443,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -479,8 +479,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -488,11 +488,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -512,8 +512,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -522,11 +522,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'+i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'+i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -538,23 +538,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -562,11 +562,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -583,23 +583,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((int)elements[i].charAt(0), pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -607,11 +607,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[n-1-i], pq.poll());
+			assertEquals(elements[n-1-i], pq.pollElement());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	@Test
@@ -623,8 +623,8 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMinHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
@@ -635,8 +635,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -645,11 +645,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MAX_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'+i));
-			assertEquals(expected, pq.poll());
+			assertEquals(expected, pq.pollElement());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	
@@ -671,10 +671,10 @@ public class BinaryHeapTests {
 			}
 			pq.change(elements[i], -1);
 			assertEquals(-1, pq.peekPriority(elements[i]));
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -689,10 +689,10 @@ public class BinaryHeapTests {
 			assertEquals(-100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertTrue(pq.isEmpty());
 		}
 		// to interior tests
@@ -709,16 +709,16 @@ public class BinaryHeapTests {
 				for (; j < n; j++) {
 					if (i != j) {
 						if (priorities[j] > -p) {
-							assertEquals(elements[j], pq.poll(), "p,i,j="+p+","+i+","+j);
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 						} else {
 							break;
 						}
 					}
 				}
-				assertEquals(elements[i], pq.poll(), "p,i,j="+p+","+i+","+j);
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
 				for (; j < n; j++) {
 					if (i!=j && priorities[j] < -p) {
-						assertEquals(elements[j], pq.poll());
+						assertEquals(elements[j], pq.pollElement());
 					}
 				}
 				assertTrue(pq.isEmpty());
@@ -733,7 +733,7 @@ public class BinaryHeapTests {
 			pq.change(elements[i], priorities[i]);
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
-				assertEquals(elements[j], pq.poll());
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}
@@ -749,15 +749,15 @@ public class BinaryHeapTests {
 			int j = 0;
 			for (; j < n; j++) {
 				if (priorities[j] > -p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				} else {
 					break;
 				}
 			}
-			assertEquals("YYY", pq.poll());
+			assertEquals("YYY", pq.pollElement());
 			for (; j < n; j++) {
 				if (priorities[j] < -p) {
-					assertEquals(elements[j], pq.poll());
+					assertEquals(elements[j], pq.pollElement());
 				}
 			}
 			assertTrue(pq.isEmpty());
@@ -773,23 +773,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -797,11 +797,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -813,23 +813,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((int)elements[i].charAt(0), pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -837,11 +837,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -853,8 +853,8 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(pairs[i]));
@@ -865,8 +865,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -875,11 +875,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'-i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'-i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -899,8 +899,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -908,11 +908,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[i], pq.pollPair());
+			assertEquals(pairs[i], pq.poll());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -944,8 +944,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -953,11 +953,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(pairs[n-1-i], pq.pollPair());
+			assertEquals(pairs[n-1-i], pq.poll());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -977,8 +977,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(pairs[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -987,11 +987,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'-i)), pq.pollPair());
+			assertEquals(new PriorityQueueNode.Integer<String>(expected, (int)('A'-i)), pq.poll());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.pollPair());
+		assertNull(pq.poll());
 	}
 	
 	@Test
@@ -1003,23 +1003,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[0], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -1027,11 +1027,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[i], pq.poll());
+			assertEquals(elements[i], pq.pollElement());
 			assertFalse(pq.contains(pairs[i].element));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,
@@ -1048,23 +1048,23 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 			assertEquals(i+1, pq.size());
 			assertFalse(pq.isEmpty());
-			assertEquals(elements[i], pq.peek());
-			assertEquals(pairs[i], pq.peekPair());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
 			assertEquals((int)elements[i].charAt(0), pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(pairs[n-1], pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -1072,11 +1072,11 @@ public class BinaryHeapTests {
 		}
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
-			assertEquals(elements[n-1-i], pq.poll());
+			assertEquals(elements[n-1-i], pq.pollElement());
 			assertFalse(pq.contains(elements[n-1-i]));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	@Test
@@ -1088,8 +1088,8 @@ public class BinaryHeapTests {
 		BinaryHeap<String> pq = BinaryHeap.createMaxHeap(8);
 		assertEquals(0, pq.size());
 		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
 		assertNull(pq.peek());
-		assertNull(pq.peekPair());
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority());
 		for (int i = 0; i < n; i++) {
 			assertTrue(pq.offer(elements[i], priorities[i]));
@@ -1100,8 +1100,8 @@ public class BinaryHeapTests {
 			assertTrue(pq.contains(elements[i]));
 			assertFalse(pq.offer(elements[i], priorities[i]));
 			assertEquals(n, pq.size());
-			assertEquals("A", pq.peek());
-			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peekPair());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Integer<String>("A",(int)'A'), pq.peek());
 			assertEquals((int)'A', pq.peekPriority());
 		}
 		for (int i = 0; i < n; i++) {
@@ -1110,11 +1110,11 @@ public class BinaryHeapTests {
 		assertEquals(Integer.MIN_VALUE, pq.peekPriority("hello"));
 		for (int i = 0; i < n; i++) {
 			String expected = ""+((char)('A'-i));
-			assertEquals(expected, pq.poll());
+			assertEquals(expected, pq.pollElement());
 			assertFalse(pq.contains(expected));
 			assertEquals(n-1-i, pq.size());
 		}
-		assertNull(pq.poll());
+		assertNull(pq.pollElement());
 	}
 	
 	

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -46,8 +46,16 @@ public class BinaryHeapTests {
 			assertTrue(pq.offer(elements[i], priorities[i]));
 		}
 		assertEquals(elements.length, pq.size());
-		String[] retain = {"A", "E", "C", "F"};
+		String[] retain = {"E", "A", "F", "C"};
 		ArrayList<Object> keepThese = new ArrayList<Object>();
+		keepThese.add(elements[0]);
+		keepThese.add(elements[1]);
+		keepThese.add(elements[2]);
+		keepThese.add(elements[3]);
+		assertFalse(pq.retainAll(keepThese));
+		assertEquals(elements.length, pq.size());
+		
+		keepThese.clear();
 		keepThese.add(retain[0]);
 		keepThese.add(retain[1]);
 		keepThese.add(new PriorityQueueNode.Integer<String>(retain[2], 5));
@@ -58,6 +66,18 @@ public class BinaryHeapTests {
 		assertTrue(pq.contains(elements[2]));
 		assertFalse(pq.contains(elements[1]));
 		assertFalse(pq.contains(elements[3]));
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[1]);
+		keepThese.add(retain[3]);
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[2]);
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(0, pq.size());
 	}
 	
 	@Test

--- a/src/test/java/org/cicirello/ds/PriorityQueueDefaultMethodTests.java
+++ b/src/test/java/org/cicirello/ds/PriorityQueueDefaultMethodTests.java
@@ -199,13 +199,4 @@ public class PriorityQueueDefaultMethodTests {
 		assertTrue(pq.removeAll(list2));
 		assertEquals(1, pq.size());
 	}
-	
-	@Test
-	public void testRetainAll() {
-		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
-		UnsupportedOperationException thrown = assertThrows( 
-			UnsupportedOperationException.class,
-			() -> pq.retainAll(new ArrayList<String>())
-		);
-	}
 }

--- a/src/test/java/org/cicirello/ds/PriorityQueueDefaultMethodTests.java
+++ b/src/test/java/org/cicirello/ds/PriorityQueueDefaultMethodTests.java
@@ -1,0 +1,211 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+
+/**
+ * JUnit tests for the default methods of the PriorityQueue interface.
+ */
+public class PriorityQueueDefaultMethodTests {
+	
+	@Test
+	public void testAdd() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.add(elements[0], 5)
+		);
+	}
+	
+	@Test
+	public void testAddPair() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i])));
+			assertEquals(i+1, pq.size());
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.add(new PriorityQueueNode.Integer<String>(elements[0], 5))
+		);
+	}
+	
+	@Test
+	public void testAddAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		ArrayList<PriorityQueueNode.Integer<String>> list = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+		}
+	}
+	
+	@Test
+	public void testContainsAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		ArrayList<PriorityQueueNode.Integer<String>> list = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		for (int i = 0; i < elements.length; i++) {
+			assertFalse(pq.containsAll(list));
+			assertTrue(pq.add(elements[i], priorities[i]));
+		}
+		assertTrue(pq.containsAll(list));
+	}
+	
+	@Test
+	public void testElement() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 2, 4, 6, 8 };
+		PriorityQueueNode.Integer<String> first = new PriorityQueueNode.Integer<String>(elements[0], priorities[0]);
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.element()
+		);
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(first, pq.element());
+		}
+		pq.clear();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[elements.length-1-i], priorities[elements.length-1-i]));
+			assertEquals(new PriorityQueueNode.Integer<String>(elements[elements.length-1-i], priorities[elements.length-1-i]), pq.element());
+		}
+	}
+	
+	@Test
+	public void testRemove() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		ArrayList<PriorityQueueNode.Integer<String>> list = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertEquals(new PriorityQueueNode.Integer<String>(elements[elements.length-1-i], priorities[elements.length-1-i]), pq.remove());
+			assertEquals(elements.length-i-1, pq.size());
+		}
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.remove()
+		);
+	}
+	
+	@Test
+	public void testRemoveElement() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		ArrayList<PriorityQueueNode.Integer<String>> list = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertEquals(elements[elements.length-1-i], pq.removeElement());
+			assertEquals(elements.length-i-1, pq.size());
+		}
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.removeElement()
+		);
+	}
+	
+	@Test
+	public void testRemoveAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		int[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		ArrayList<PriorityQueueNode.Integer<String>> list = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list));
+		assertEquals(0, pq.size());
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list.remove(list.size()-1);
+		assertTrue(pq.removeAll(list));
+		assertEquals(1, pq.size());
+		
+		list.clear();
+		ArrayList<String> list2 = new ArrayList<String>();
+		for (int i = 0; i < elements.length; i++) {
+			list2.add(elements[i]);
+			list.add(new PriorityQueueNode.Integer<String>(elements[i], priorities[i]));
+		}
+		pq.clear();
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list2));
+		assertEquals(0, pq.size());
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list2.remove(list.size()-1);
+		assertTrue(pq.removeAll(list2));
+		assertEquals(1, pq.size());
+	}
+	
+	@Test
+	public void testRetainAll() {
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		UnsupportedOperationException thrown = assertThrows( 
+			UnsupportedOperationException.class,
+			() -> pq.retainAll(new ArrayList<String>())
+		);
+	}
+}

--- a/src/test/java/org/cicirello/ds/PriorityQueueDoubleDefaultMethodTests.java
+++ b/src/test/java/org/cicirello/ds/PriorityQueueDoubleDefaultMethodTests.java
@@ -1,0 +1,211 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+
+/**
+ * JUnit tests for the default methods of the PriorityQueueDouble interface.
+ */
+public class PriorityQueueDoubleDefaultMethodTests {
+	
+	@Test
+	public void testAdd() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.add(elements[0], 5)
+		);
+	}
+	
+	@Test
+	public void testAddPair() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i])));
+			assertEquals(i+1, pq.size());
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.add(new PriorityQueueNode.Double<String>(elements[0], 5))
+		);
+	}
+	
+	@Test
+	public void testAddAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+	}
+	
+	@Test
+	public void testContainsAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		for (int i = 0; i < elements.length; i++) {
+			assertFalse(pq.containsAll(list));
+			assertTrue(pq.add(elements[i], priorities[i]));
+		}
+		assertTrue(pq.containsAll(list));
+	}
+	
+	@Test
+	public void testElement() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 2, 4, 6, 8 };
+		PriorityQueueNode.Double<String> first = new PriorityQueueNode.Double<String>(elements[0], priorities[0]);
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.element()
+		);
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(first, pq.element());
+		}
+		pq.clear();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.add(elements[elements.length-1-i], priorities[elements.length-1-i]));
+			assertEquals(new PriorityQueueNode.Double<String>(elements[elements.length-1-i], priorities[elements.length-1-i]), pq.element());
+		}
+	}
+	
+	@Test
+	public void testRemove() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertEquals(new PriorityQueueNode.Double<String>(elements[elements.length-1-i], priorities[elements.length-1-i]), pq.remove());
+			assertEquals(elements.length-i-1, pq.size());
+		}
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.remove()
+		);
+	}
+	
+	@Test
+	public void testRemoveElement() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertEquals(elements[elements.length-1-i], pq.removeElement());
+			assertEquals(elements.length-i-1, pq.size());
+		}
+		NoSuchElementException thrown = assertThrows( 
+			NoSuchElementException.class,
+			() -> pq.removeElement()
+		);
+	}
+	
+	@Test
+	public void testRemoveAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list));
+		assertEquals(0, pq.size());
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list.remove(list.size()-1);
+		assertTrue(pq.removeAll(list));
+		assertEquals(1, pq.size());
+		
+		list.clear();
+		ArrayList<String> list2 = new ArrayList<String>();
+		for (int i = 0; i < elements.length; i++) {
+			list2.add(elements[i]);
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		pq.clear();
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list2));
+		assertEquals(0, pq.size());
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list2.remove(list.size()-1);
+		assertTrue(pq.removeAll(list2));
+		assertEquals(1, pq.size());
+	}
+	
+	@Test
+	public void testRetainAll() {
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		UnsupportedOperationException thrown = assertThrows( 
+			UnsupportedOperationException.class,
+			() -> pq.retainAll(new ArrayList<String>())
+		);
+	}
+}

--- a/src/test/java/org/cicirello/ds/PriorityQueueDoubleDefaultMethodTests.java
+++ b/src/test/java/org/cicirello/ds/PriorityQueueDoubleDefaultMethodTests.java
@@ -199,13 +199,4 @@ public class PriorityQueueDoubleDefaultMethodTests {
 		assertTrue(pq.removeAll(list2));
 		assertEquals(1, pq.size());
 	}
-	
-	@Test
-	public void testRetainAll() {
-		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
-		UnsupportedOperationException thrown = assertThrows( 
-			UnsupportedOperationException.class,
-			() -> pq.retainAll(new ArrayList<String>())
-		);
-	}
 }


### PR DESCRIPTION
## Summary
Refactored PriorityQueue interfaces and classes that implement them. As part of this, PriorityQueue interfaces now extend Java's Queue interface.

## Closing Issues
Closes #34 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
