### PR TITLE
Added binary heap of int values with double priorities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-05-18
+## [Unreleased] - 2022-05-19
 
 **BREAKING CHANGES:** See changes section for details. Breaking changes include increasing
 minimum supported Java version to Java 17.
@@ -12,11 +12,12 @@ minimum supported Java version to Java 17.
 ### Added
 * DisjointSetForest: representation of disjoint sets of generic objects.
 * DisjointIntegerSetForest: representation of disjoint sets of integers with a disjoint set forest.
-* PriorityQueue: interface to different implementations of priority queues with int-valued priorities.
-* PriorityQueueDouble: interface to different implementations of priority queues with double-valued priorities.
+* PriorityQueue: interface for priority queues with int-valued priorities.
+* PriorityQueueDouble: interface for priority queues with double-valued priorities.
 * BinaryHeap: implements PriorityQueue with binary heap for both min-heap and max-heap cases.
 * BinaryHeapDouble: implements PriorityQueueDouble with binary heap for both min-heap and max-heap cases.
-* IntPriorityQueue: interface to implementations of priority queues of int elements with int-valued priorities.
+* IntPriorityQueue: interface for priority queues of int elements with int-valued priorities.
+* IntPriorityQueueDouble: interface for priority queues of int elements with double-valued priorities.
 * IntBinaryHeap: implements IntPriorityQueue with binary heap for both min-heap and max-heap cases.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ minimum supported Java version to Java 17.
 * IntPriorityQueue: interface for priority queues of int elements with int-valued priorities.
 * IntPriorityQueueDouble: interface for priority queues of int elements with double-valued priorities.
 * IntBinaryHeap: implements IntPriorityQueue with binary heap for both min-heap and max-heap cases.
+* IntBinaryHeapDouble: implements IntPriorityQueueDouble with binary heap for both min-heap and max-heap cases.
 
 ### Changed
 * Minimum supported Java version is now Java 17.

--- a/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
@@ -1,0 +1,371 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import java.util.Arrays;
+
+import org.cicirello.util.Copyable;
+
+/**
+ * <p>An implementation of a Binary Heap of
+ * (element, priority) pairs, such that the elements are distinct integers
+ * in the interval [0, n), and with priority values of type double.</p> 
+ *
+ * <p><b>Priority order:</b>
+ * IntBinaryHeapDouble instances are created via factory methods with names beginning
+ * with <code>create</code>. The priority order depends upon the factory method
+ * used to create the IntBinaryHeapDouble. Methods named <code>createMinHeap</code> produce
+ * a min heap with priority order minimum-priority-first-out. Methods named 
+ * <code>createMaxHeap</code> produce a max heap with priority order 
+ * maximum-priority-first-out.</p>
+ *
+ * <p><b>Creating instances:</b> To create an instance, use one of the factory
+ * methods. In this example an IntBinaryHeapDouble with an element domain of [0,100)
+ * is created:</p>
+ * <pre><code>
+ * IntBinaryHeapDouble&lt;String&gt; pq = IntBinaryHeapDouble.createMinHeap(100);
+ * </code></pre>
+ * <p>In the above example, the element domain is [0,100) and the IntBinaryHeapDouble
+ * is initially empty.</p>
+ *
+ * <p><b>Purpose:</b> The purpose of such an IntBinaryHeapDouble is to support
+ * implementations of algorithms that require such a specialized case.
+ * For example, some graph algorithms such as Dijkstra's algorithm for 
+ * single-source shortest paths, and Prim's algorithm for minimum spanning
+ * tree, rely on a priority queue of the vertex ids, which are usually
+ * ints in some finite range. Although such applications could use the
+ * classes that instead implement the {@link PriorityQueueDouble} interface,
+ * using Java's wrapper type {@link Integer}, the classes that implement
+ * {@link IntPriorityQueueDouble} that specialize the element type to int
+ * are optimized for this special case.</p>
+ *
+ * <p>For a more general purpose binary heap, see the {@link BinaryHeapDouble}
+ * class.</p>
+ *
+ * <p><b>Method runtimes:</b> The asymptotic runtime of the methods of
+ * this class are as follows (where n is the current size of the heap):</p>
+ * <ul>
+ * <li><b>O(1):</b> {@link #contains(int)}, {@link #createMaxHeap(int)}, 
+ *     {@link #createMinHeap(int)}, {@link #domain()}, {@link #isEmpty()},
+ *     {@link #peek()}, {@link #peekPriority()}, {@link #peekPriority(int)}, {@link #size()}</li>
+ * <li><b>O(lg n):</b> {@link #change(int,double)}, {@link #offer(int, double)}, {@link #poll()}</li>
+ * <li><b>O(n):</b> {@link #clear()}, {@link #copy()}</li>
+ * </ul>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<IntBinaryHeapDouble> {
+	
+	private final int[] heap;
+	private final int[] index;
+	private final double[] value;
+	private final boolean[] in;
+	private int size;
+	
+	/**
+	 * Initializes an empty min-heap of (int, priority) pairs,
+	 * such that the domain of the elements are the integers in [0, n).
+	 *
+	 * @param n The size of the domain of the elements of the min-heap.
+	 */
+	private IntBinaryHeapDouble(int n) {
+		heap = new int[n];
+		index = new int[n];
+		value = new double[n];
+		in = new boolean[n];
+	}
+	
+	/*
+	 * private copy constructor to support copy() nethod
+	 */
+	private IntBinaryHeapDouble(IntBinaryHeapDouble other) {
+		heap = other.heap.clone();
+		index = other.index.clone();
+		value = other.value.clone();
+		in = other.in.clone();
+		size = other.size;
+	}
+	
+	@Override
+	public IntBinaryHeapDouble copy() {
+		return new IntBinaryHeapDouble(this);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final void change(int element, double priority) {
+		if (!offer(element, priority)) {
+			internalChange(element, priority);
+		}
+	}
+	
+	@Override
+	public final void clear() {
+		if (size > 0) {
+			Arrays.fill(in, 0, size, false);
+			size = 0;
+		}
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean contains(int element) {
+		return in[element];
+	}
+	
+	/**
+	 * Initializes an empty max-heap of (int, priority) pairs,
+	 * such that the domain of the elements are the integers in [0, n).
+	 *
+	 * @param n The size of the domain of the elements of the max-heap.
+	 *
+	 * @return an empty max-heap
+	 */
+	public static IntBinaryHeapDouble createMaxHeap(int n) {
+		if (n < 1) {
+			throw new IllegalArgumentException("domain must be positive");
+		}
+		return new IntBinaryHeapDouble.Max(n);
+	}
+	
+	/**
+	 * Initializes an empty min-heap of (int, priority) pairs,
+	 * such that the domain of the elements are the integers in [0, n).
+	 *
+	 * @param n The size of the domain of the elements of the min-heap.
+	 *
+	 * @return an empty min-heap
+	 */
+	public static IntBinaryHeapDouble createMinHeap(int n) {
+		if (n < 1) {
+			throw new IllegalArgumentException("domain must be positive");
+		}
+		return new IntBinaryHeapDouble(n);
+	}
+	
+	@Override
+	public final int domain() {
+		return index.length;
+	}
+	
+	@Override
+	public final boolean isEmpty() {
+		return size == 0;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean offer(int element, double priority) {
+		if (in[element]) {
+			return false;
+		}
+		index[heap[size] = element] = size;
+		value[element] = priority;
+		in[element] = true;
+		percolateUp(size);
+		size++;
+		return true;
+	}
+	
+	@Override
+	public final int peek() {
+		return heap[0];
+	}
+	
+	@Override
+	public final double peekPriority() {
+		return value[heap[0]];
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final double peekPriority(int element) {
+		return value[element];
+	}
+	
+	@Override
+	public final int poll() {
+		int min = heap[0];
+		in[min] = false;
+		size--;
+		if (size > 0) {
+			index[heap[0] = heap[size]] = 0;
+			percolateDown(0);
+		} 
+		return min;
+	}
+	
+	@Override
+	public final int size() {
+		return size;
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	void internalChange(int element, double priority) {
+		if (priority < value[element]) {
+			value[element] = priority;
+			percolateUp(index[element]);
+		} else if (priority > value[element]) {
+			value[element] = priority;
+			percolateDown(index[element]);
+		}
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	void percolateDown(int i) {
+		int left; 
+		while ((left = (i << 1) + 1) < size) { 
+			int smallest = i;
+			if (value[heap[left]] < value[heap[i]]) {
+				smallest = left;
+			}
+			int right = left + 1;
+			if (right < size && value[heap[right]] < value[heap[smallest]]) {
+				smallest = right;
+			}
+			if (smallest != i) {
+				int temp = heap[i];
+				index[heap[i] = heap[smallest]] = i;
+				index[heap[smallest] = temp] = smallest;
+				i = smallest; 
+			} else {
+				break;
+			}
+		}
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	void percolateUp(int i) {
+		int parent;
+		while (i > 0 && value[heap[parent = (i-1) >> 1]] > value[heap[i]]) {
+			int temp = heap[i];
+			index[heap[i] = heap[parent]] = i;
+			index[heap[parent] = temp] = parent;
+			i = parent;
+		}
+	}
+	
+	private static final class Max extends IntBinaryHeapDouble {
+		
+		private final IntBinaryHeapDouble self;
+		
+		private Max(int n) {
+			super(n);
+			self = this;
+		}
+		
+		/*
+		 * private copy constructor to support copy() nethod
+		 */
+		private Max(Max other) {
+			super(other);
+			self = this;
+		}
+		
+		@Override
+		public Max copy() {
+			return new Max(this);
+		}
+		
+		/*
+		 * max heap order
+		 */
+		void internalChange(int element, double priority) {
+			if (priority > self.value[element]) {
+				self.value[element] = priority;
+				percolateUp(self.index[element]);
+			} else if (priority < self.value[element]) {
+				self.value[element] = priority;
+				percolateDown(self.index[element]);
+			}
+		}
+		
+		/*
+		 * max heap order
+		 */
+		void percolateDown(int i) {
+			int left; 
+			while ((left = (i << 1) + 1) < self.size) { 
+				int smallest = i;
+				if (self.value[self.heap[left]] > self.value[self.heap[i]]) {
+					smallest = left;
+				}
+				int right = left + 1;
+				if (right < self.size && self.value[self.heap[right]] > self.value[self.heap[smallest]]) {
+					smallest = right;
+				}
+				if (smallest != i) {
+					int temp = self.heap[i];
+					self.index[self.heap[i] = self.heap[smallest]] = i;
+					self.index[self.heap[smallest] = temp] = smallest;
+					i = smallest; 
+				} else {
+					break;
+				}
+			}
+		}
+		
+		/*
+		 * max heap order
+		 */
+		void percolateUp(int i) {
+			int parent;
+			while (i > 0 && self.value[self.heap[parent = (i-1) >> 1]] < self.value[self.heap[i]]) {
+				int temp = self.heap[i];
+				self.index[self.heap[i] = self.heap[parent]] = i;
+				self.index[self.heap[parent] = temp] = parent;
+				i = parent;
+			}
+		}
+	}
+}

--- a/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
@@ -1,0 +1,156 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+/**
+ * <p>Interface common to the classes that provide implementations of
+ * a priority queue of (element, priority) pairs, such that the elements
+ * are int values in the interval [0, n), and priorities are doubles.
+ * All IntPriorityQueueDouble implementations enforce distinct elements.</p>
+ *
+ * <p>The purpose of such a priority queue implementation is to support
+ * implementations of algorithms that require such a specialized case.
+ * For example, some graph algorithms such as Dijkstra's algorithm for 
+ * single-source shortest paths, and Prim's algorithm for minimum spanning
+ * tree, rely on a priority queue of the vertex ids, which are usually
+ * ints in some finite range. Although such applications could use the
+ * classes that instead implement the {@link PriorityQueueDouble} interface,
+ * using Java's wrapper type {@link Integer}, the classes that implement
+ * {@link IntPriorityQueueDouble} that specialize the element type to int
+ * are optimized for this special case.</p>
+ *
+ * <p>For a more general purpose priority queue, see the {@link PriorityQueueDouble}
+ * interface and the classes that implement it.</p>
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public interface IntPriorityQueueDouble {
+	
+	/**
+	 * Changes the priority of an element if the element is
+	 * present in the IntPriorityQueueDouble, and otherwise adds the
+	 * (element, priority) pair to the IntPriorityQueueDouble.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	void change(int element, double priority);
+	
+	/**
+	 * Clears the IntPriorityQueueDouble, removing all elements.
+	 */
+	void clear();
+	
+	/**
+	 * Checks if an element is in the IntPriorityQueueDouble.
+	 *
+	 * @param element The element to check for containment.
+	 *
+	 * @return true if and only if there exists an (element, priority) pair
+	 * for the specified element.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	boolean contains(int element);
+	
+	/**
+	 * Returns the domain of this IntPriorityQueueDouble. Note that the domain
+	 * is not the same thing as the size. The domain defines the elements
+	 * that are allowed in the IntPriorityQueueDouble, whether or not they actually appear within it.
+	 *
+	 * @return the domain of this IntPriorityQueueDouble
+	 */
+	int domain();
+	
+	/**
+	 * Checks if the IntPriorityQueueDouble is empty.
+	 *
+	 * @return true if and only if it is empty
+	 */
+	boolean isEmpty();
+	
+	/**
+	 * Adds an (element, priority) pair to the IntPriorityQueueDouble with a specified priority,
+	 * provided the element is not already in the IntPriorityQueueDouble.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * IntPriorityQueueDouble already contained the element.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	boolean offer(int element, double priority);
+	
+	/**
+	 * Gets the next element in priority order from this IntPriorityQueueDouble,
+	 * without removing it. Behavior is undefined if it is empty.
+	 *
+	 * @return the next element in priority order.
+	 */
+	int peek();
+	
+	/**
+	 * Gets the priority of the next element in priority order in the IntPriorityQueueDouble.
+	 * Behavior is undefined if it is empty.
+	 *
+	 * @return the priority of the next element in priority order.
+	 */
+	double peekPriority();
+	
+	/**
+	 * Gets the current priority of a specified element in the IntPriorityQueueDouble.
+	 * Behavior is undefined if the IntPriorityQueueDouble doesn't contain the element.
+	 *
+	 * @param element the element whose priority is returned
+	 *
+	 * @return the current priority of element.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	double peekPriority(int element);
+	
+	/**
+	 * Gets and removes the next element in priority order from this IntPriorityQueueDouble.
+	 * Behavior is undefined if it is empty.
+	 *
+	 * @return the next element in priority order.
+	 */
+	int poll();
+	
+	/**
+	 * Gets the current size of the IntPriorityQueueDouble, which is the
+	 * number of (element, priority) pairs that it contains.
+	 *
+	 * @return the current size of the IntPriorityQueueDouble.
+	 */
+	int size();
+}

--- a/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
@@ -1,0 +1,637 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * JUnit tests for the IntBinaryHeapDouble class.
+ */
+public class IntBinaryHeapDoubleTests {
+	
+	// Tests not specific to min heap vs max heap
+	
+	@Test
+	public void testCopy() {
+		IntBinaryHeapDouble min1 = IntBinaryHeapDouble.createMinHeap(10);
+		for (int i = 0; i < 5; i++) {
+			min1.offer(i, 42*i);
+		}
+		IntBinaryHeapDouble min2 = IntBinaryHeapDouble.createMinHeap(10);
+		for (int i = 0; i < 5; i++) {
+			min2.offer(i, 43*i);
+		}
+		IntBinaryHeapDouble max1 = IntBinaryHeapDouble.createMaxHeap(10);
+		for (int i = 0; i < 5; i++) {
+			max1.offer(i, 42*i);
+		}
+		IntBinaryHeapDouble max2 = IntBinaryHeapDouble.createMaxHeap(10);
+		for (int i = 0; i < 5; i++) {
+			max2.offer(i, 43*i);
+		}
+		IntBinaryHeapDouble minCopy1 = min1.copy();
+		IntBinaryHeapDouble minCopy2 = min2.copy();
+		IntBinaryHeapDouble maxCopy1 = max1.copy();
+		IntBinaryHeapDouble maxCopy2 = max2.copy();
+		assertTrue(min1 != minCopy1);
+		assertTrue(min2 != minCopy2);
+		assertTrue(max1 != maxCopy1);
+		assertTrue(max2 != maxCopy2);
+		assertEquals(min1.getClass(), minCopy1.getClass());
+		assertEquals(min2.getClass(), minCopy2.getClass());
+		assertEquals(max1.getClass(), maxCopy1.getClass());
+		assertEquals(max2.getClass(), maxCopy2.getClass());
+		assertEquals(min1.size(), minCopy1.size());
+		assertEquals(min2.size(), minCopy2.size());
+		assertEquals(max1.size(), maxCopy1.size());
+		assertEquals(max2.size(), maxCopy2.size());
+		assertNotEquals(min1.getClass(), maxCopy1.getClass());
+		assertNotEquals(min2.getClass(), maxCopy2.getClass());
+		assertNotEquals(max1.getClass(), minCopy1.getClass());
+		assertNotEquals(max2.getClass(), minCopy2.getClass());
+		int n = min1.size();
+		for (int i = 0; i < n; i++) {
+			assertEquals(min1.peek(), minCopy1.peek());
+			assertEquals(min2.peek(), minCopy2.peek());
+			assertEquals(max1.peek(), maxCopy1.peek());
+			assertEquals(max2.peek(), maxCopy2.peek());
+			assertEquals(min1.peekPriority(), minCopy1.peekPriority(), 0.0);
+			assertEquals(min2.peekPriority(), minCopy2.peekPriority(), 0.0);
+			assertEquals(max1.peekPriority(), maxCopy1.peekPriority(), 0.0);
+			assertEquals(max2.peekPriority(), maxCopy2.peekPriority(), 0.0);
+			assertEquals(min1.poll(), minCopy1.poll());
+			assertEquals(min2.poll(), minCopy2.poll());
+			assertEquals(max1.poll(), maxCopy1.poll());
+			assertEquals(max2.poll(), maxCopy2.poll());
+		}
+		assertTrue(min1.isEmpty());
+		assertTrue(min2.isEmpty());
+		assertTrue(max1.isEmpty());
+		assertTrue(max2.isEmpty());
+		assertTrue(minCopy1.isEmpty());
+		assertTrue(minCopy2.isEmpty());
+		assertTrue(maxCopy1.isEmpty());
+		assertTrue(maxCopy2.isEmpty());
+	}
+	
+	// MIN HEAP TESTS
+	
+	@Test
+	public void testCreateMinHeap() {
+		for (int n = 1; n <= 4; n++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			assertEquals(0, pq.size());
+			assertTrue(pq.isEmpty());
+			assertEquals(n, pq.domain());
+			for (int i = 0; i < n; i++) {
+				assertFalse(pq.contains(i));
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> IntBinaryHeapDouble.createMinHeap(0)
+		);
+	}
+	
+	@Test
+	public void testClearMinHeap() {
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(10);
+		for (int i = 0; i < 5; i++) {
+			pq.offer(i, 42*i);
+		}
+		assertEquals(5, pq.size());
+		pq.clear();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(10, pq.domain());
+		pq.clear();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(10, pq.domain());
+	}
+	
+	@Test
+	public void testIncreasingPriorityMinHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(e[0], pq.peek());
+			assertEquals(p[0], pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			assertEquals(e[i], pq.poll(), "p[i],e[i]="+p[i]+","+e[i]);
+			assertEquals(n-1-i, pq.size());
+			assertFalse(pq.contains(e[i]));
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testDecreasingPriorityMinHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = reversedArray(n);
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(e[i], pq.peek());
+			assertEquals(p[i], pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			assertEquals(e[n-1-i], pq.poll(), "p[i],e[i]="+p[i]+","+e[i]);
+			assertEquals(n-1-i, pq.size());
+			assertFalse(pq.contains(e[n-1-i]));
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testRandomPriorityMinHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = shuffle(orderedArray(n));
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		double minP = Integer.MAX_VALUE;
+		int minE = -1;
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			if (p[i] < minP) {
+				minP = p[i];
+				minE = e[i];
+			}
+			assertEquals(minE, pq.peek());
+			assertEquals(minP, pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		double lastP = -1000;
+		double[] expectedP = new double[n];
+		for (int i = 0; i < n; i++) {
+			expectedP[e[i]] = p[i];
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			double nextP = pq.peekPriority();
+			assertTrue(nextP >= lastP);
+			assertEquals(nextP, expectedP[pq.poll()], 0.0, "p[i],e[i]="+p[i]+","+e[i]);
+			lastP = nextP;
+			assertEquals(n-1-i, pq.size());
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testChangePriorityMinHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = 2*p[i] + 2;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], 1);
+			assertEquals(1, pq.peekPriority(e[i]), 0.0);
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], 100);
+			assertEquals(100, pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				pq.change(e[i], pNew);
+				assertEquals(pNew, pq.peekPriority(e[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] < pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] > pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], p[i]);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[n-1], pNew);
+			assertEquals(pNew, pq.peekPriority(e[n-1]), 0.0);
+			int j = 0;
+			for (; j < n-1; j++) {
+				if (p[j] < pNew) {
+					assertEquals(e[j], pq.poll());
+				} else {
+					break;
+				}
+			}
+			assertEquals(e[n-1], pq.poll());
+			for (; j < n-1; j++) {
+				if (p[j] > pNew) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	// MAX HEAP TESTS
+	
+	@Test
+	public void testCreateMaxHeap() {
+		for (int n = 1; n <= 4; n++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			assertEquals(0, pq.size());
+			assertTrue(pq.isEmpty());
+			assertEquals(n, pq.domain());
+			for (int i = 0; i < n; i++) {
+				assertFalse(pq.contains(i));
+			}
+		}
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> IntBinaryHeapDouble.createMaxHeap(0)
+		);
+	}
+	
+	@Test
+	public void testClearMaxHeap() {
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(10);
+		for (int i = 0; i < 5; i++) {
+			pq.offer(i, 42*i);
+		}
+		assertEquals(5, pq.size());
+		pq.clear();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(10, pq.domain());
+		pq.clear();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(10, pq.domain());
+	}
+	
+	@Test
+	public void testIncreasingPriorityMaxHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = reversedArray(n);
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(e[0], pq.peek());
+			assertEquals(p[0], pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			assertEquals(e[i], pq.poll(), "p[i],e[i]="+p[i]+","+e[i]);
+			assertEquals(n-1-i, pq.size());
+			assertFalse(pq.contains(e[i]));
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testDecreasingPriorityMaxHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(e[i], pq.peek());
+			assertEquals(p[i], pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			assertEquals(e[n-1-i], pq.poll(), "p[i],e[i]="+p[i]+","+e[i]);
+			assertEquals(n-1-i, pq.size());
+			assertFalse(pq.contains(e[n-1-i]));
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testRandomPriorityMaxHeap() {
+		int n = 31;
+		int[] e = createElements(n);
+		double[] p = shuffle(orderedArray(n));
+		IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertEquals(n, pq.domain());
+		double maxP = Integer.MIN_VALUE;
+		int maxE = -1;
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(e[i], p[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			if (p[i] > maxP) {
+				maxP = p[i];
+				maxE = e[i];
+			}
+			assertEquals(maxE, pq.peek());
+			assertEquals(maxP, pq.peekPriority(), 0.0);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertTrue(pq.contains(e[i]));
+			assertFalse(pq.offer(e[i], p[i]));
+		}
+		double lastP = 1000;
+		double[] expectedP = new double[n];
+		for (int i = 0; i < n; i++) {
+			expectedP[e[i]] = p[i];
+		}
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.isEmpty());
+			double nextP = pq.peekPriority();
+			assertTrue(nextP <= lastP);
+			assertEquals(nextP, expectedP[pq.poll()], 0.0, "p[i],e[i]="+p[i]+","+e[i]);
+			lastP = nextP;
+			assertEquals(n-1-i, pq.size());
+		}
+		assertTrue(pq.isEmpty());
+	}
+	
+	@Test
+	public void testChangePriorityMaxHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = -(2*p[i] + 2);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], -1);
+			assertEquals(-1, pq.peekPriority(e[i]), 0.0);
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], -100);
+			assertEquals(-100, pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				pq.change(e[i], -pNew);
+				assertEquals(-pNew, pq.peekPriority(e[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] > -pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] < -pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[i], p[i]);
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			pq.change(e[n-1], -pNew);
+			assertEquals(-pNew, pq.peekPriority(e[n-1]), 0.0);
+			int j = 0;
+			for (; j < n-1; j++) {
+				if (p[j] > -pNew) {
+					assertEquals(e[j], pq.poll());
+				} else {
+					break;
+				}
+			}
+			assertEquals(e[n-1], pq.poll());
+			for (; j < n-1; j++) {
+				if (p[j] < -pNew) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	private int[] createElements(int n) {
+		return shuffle(orderedArrayInt(n));
+	}
+	
+	private double[] orderedArray(int n) {
+		double[] e = new double[n];
+		for (int i = 0; i < n; i++) {
+			e[i] = i;
+		}
+		return e;
+	}
+	
+	private int[] orderedArrayInt(int n) {
+		int[] e = new int[n];
+		for (int i = 0; i < n; i++) {
+			e[i] = i;
+		}
+		return e;
+	}
+	
+	private double[] reversedArray(int n) {
+		double[] e = orderedArray(n);
+		for (int i = 0, j = n-1; i < j; i++, j--) {
+			double temp = e[i];
+			e[i] = e[j];
+			e[j] = temp;
+		}
+		return e;
+	}
+	
+	private int[] shuffle(int[] e) {
+		for (int i = e.length - 1; i > 0; i--) {
+			int j = ThreadLocalRandom.current().nextInt(i+1);
+			if (i != j) {
+				int temp = e[i];
+				e[i] = e[j];
+				e[j] = temp;
+			}
+		}
+		return e;
+	}
+	
+	private double[] shuffle(double[] e) {
+		for (int i = e.length - 1; i > 0; i--) {
+			int j = ThreadLocalRandom.current().nextInt(i+1);
+			if (i != j) {
+				double temp = e[i];
+				e[i] = e[j];
+				e[j] = temp;
+			}
+		}
+		return e;
+	}
+}


### PR DESCRIPTION
## Summary
Added the following:
* IntPriorityQueueDouble: interface for priority queues of int elements with double-valued priorities.
* IntBinaryHeapDouble: implements IntPriorityQueueDouble with binary heap for both min-heap and max-heap cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
