### PR TITLE
Fixed bug in BinaryHeap and BinaryHeapDouble with potential to break encapsulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Bug in BinaryHeap and BinaryHeapDouble with potential to break encapsulation.
 
 ### CI/CD
 

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -148,8 +148,8 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 			if (index.containsKey(element.element)) {
 				throw new IllegalArgumentException("initialElements contains duplicates");
 			}
-			buffer[size] = element;
-			index.put(element.element, size);
+			buffer[size] = element.copy();
+			index.put(buffer[size].element, size);
 			size++;
 		}
 		buildHeap();
@@ -378,7 +378,7 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 		if (contains(pair.element)) {
 			return false;
 		}
-		return internalOffer(pair);
+		return internalOffer(pair.copy());
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -148,8 +148,8 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 			if (index.containsKey(element.element)) {
 				throw new IllegalArgumentException("initialElements contains duplicates");
 			}
-			buffer[size] = element;
-			index.put(element.element, size);
+			buffer[size] = element.copy();
+			index.put(buffer[size].element, size);
 			size++;
 		}
 		buildHeap();
@@ -378,7 +378,7 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 		if (contains(pair.element)) {
 			return false;
 		}
-		return internalOffer(pair);
+		return internalOffer(pair.copy());
 	}
 	
 	@Override


### PR DESCRIPTION
## Summary
Fixed bug in BinaryHeap and BinaryHeapDouble with potential to break encapsulation.

## Closing Issues
Closes #47 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
