### PR TITLE
Modified change method of priority queue interfaces and classes to return boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * FibonacciHeapDouble: implements PriorityQueueDouble with a Fibonacci heap for both min-heap and max-heap cases.
 
 ### Changed
+* The change method of the PriorityQueue, PriorityQueueDouble, IntPriorityQueue, IntPriorityQueueDouble
+  interfaces, and of the classes that implement them now return a boolean.
 
 ### Deprecated
 

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -269,17 +269,21 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 	}
 	
 	@Override
-	public final void change(E element, int priority) {
+	public final boolean change(E element, int priority) {
 		if (!offer(element, priority)) {
 			int i = index.get(element);
 			if (compare.belongsAbove(priority, buffer[i].value)) {
 				buffer[i].value = priority;
 				percolateUp(i);
+				return true;
 			} else if (compare.belongsAbove(buffer[i].value, priority)) {
 				buffer[i].value = priority;
 				percolateDown(i);
+				return true;
 			}
+			return false;
 		}
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -269,17 +269,21 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 	}
 	
 	@Override
-	public final void change(E element, double priority) {
+	public final boolean change(E element, double priority) {
 		if (!offer(element, priority)) {
 			int i = index.get(element);
 			if (compare.belongsAbove(priority, buffer[i].value)) {
 				buffer[i].value = priority;
 				percolateUp(i);
+				return true;
 			} else if (compare.belongsAbove(buffer[i].value, priority)) {
 				buffer[i].value = priority;
 				percolateDown(i);
+				return true;
 			}
+			return false;
 		}
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/FibonacciHeap.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeap.java
@@ -232,17 +232,21 @@ public final class FibonacciHeap<E> implements PriorityQueue<E>, Copyable<Fibona
 	}
 	
 	@Override
-	public final void change(E element, int priority) {
+	public final boolean change(E element, int priority) {
 		if (!offer(element, priority)) {
 			// No need to null check this because condition above guarantees
 			// that this should be non-null.
 			Node<E> node = index.get(element);
 			if (compare.comesBefore(priority, node.e.value)) {
 				internalPromote(node, priority);
+				return true;
 			} else if (compare.comesBefore(node.e.value, priority)) {
 				internalDemote(node, priority);
+				return true;
 			}
+			return false;
 		}
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
@@ -232,17 +232,21 @@ public final class FibonacciHeapDouble<E> implements PriorityQueueDouble<E>, Cop
 	}
 	
 	@Override
-	public final void change(E element, double priority) {
+	public final boolean change(E element, double priority) {
 		if (!offer(element, priority)) {
 			// No need to null check this because condition above guarantees
 			// that this should be non-null.
 			Node<E> node = index.get(element);
 			if (compare.comesBefore(priority, node.e.value)) {
 				internalPromote(node, priority);
+				return true;
 			} else if (compare.comesBefore(node.e.value, priority)) {
 				internalDemote(node, priority);
+				return true;
 			}
+			return false;
 		}
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/IntBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeap.java
@@ -119,10 +119,11 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 	 *     or equal to the domain n.
 	 */
 	@Override
-	public final void change(int element, int priority) {
+	public final boolean change(int element, int priority) {
 		if (!offer(element, priority)) {
-			internalChange(element, priority);
+			return internalChange(element, priority);
 		}
+		return true;
 	}
 	
 	@Override
@@ -245,14 +246,17 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 	 * package-private to enable overriding in 
 	 * nested subclass to support max heaps.
 	 */
-	void internalChange(int element, int priority) {
+	boolean internalChange(int element, int priority) {
 		if (priority < value[element]) {
 			value[element] = priority;
 			percolateUp(index[element]);
+			return true;
 		} else if (priority > value[element]) {
 			value[element] = priority;
 			percolateDown(index[element]);
+			return true;
 		}
+		return false;
 	}
 	
 	/*
@@ -320,19 +324,24 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 		/*
 		 * max heap order
 		 */
-		void internalChange(int element, int priority) {
+		@Override
+		boolean internalChange(int element, int priority) {
 			if (priority > self.value[element]) {
 				self.value[element] = priority;
 				percolateUp(self.index[element]);
+				return true;
 			} else if (priority < self.value[element]) {
 				self.value[element] = priority;
 				percolateDown(self.index[element]);
+				return true;
 			}
+			return false;
 		}
 		
 		/*
 		 * max heap order
 		 */
+		@Override
 		void percolateDown(int i) {
 			int left; 
 			while ((left = (i << 1) + 1) < self.size) { 
@@ -358,6 +367,7 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 		/*
 		 * max heap order
 		 */
+		@Override
 		void percolateUp(int i) {
 			int parent;
 			while (i > 0 && self.value[self.heap[parent = (i-1) >> 1]] < self.value[self.heap[i]]) {

--- a/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
@@ -119,10 +119,11 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 	 *     or equal to the domain n.
 	 */
 	@Override
-	public final void change(int element, double priority) {
+	public final boolean change(int element, double priority) {
 		if (!offer(element, priority)) {
-			internalChange(element, priority);
+			return internalChange(element, priority);
 		}
+		return true;
 	}
 	
 	@Override
@@ -245,14 +246,17 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 	 * package-private to enable overriding in 
 	 * nested subclass to support max heaps.
 	 */
-	void internalChange(int element, double priority) {
+	boolean internalChange(int element, double priority) {
 		if (priority < value[element]) {
 			value[element] = priority;
 			percolateUp(index[element]);
+			return true;
 		} else if (priority > value[element]) {
 			value[element] = priority;
 			percolateDown(index[element]);
+			return true;
 		}
+		return false;
 	}
 	
 	/*
@@ -320,19 +324,24 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 		/*
 		 * max heap order
 		 */
-		void internalChange(int element, double priority) {
+		@Override
+		boolean internalChange(int element, double priority) {
 			if (priority > self.value[element]) {
 				self.value[element] = priority;
 				percolateUp(self.index[element]);
+				return true;
 			} else if (priority < self.value[element]) {
 				self.value[element] = priority;
 				percolateDown(self.index[element]);
+				return true;
 			}
+			return false;
 		}
 		
 		/*
 		 * max heap order
 		 */
+		@Override
 		void percolateDown(int i) {
 			int left; 
 			while ((left = (i << 1) + 1) < self.size) { 
@@ -358,6 +367,7 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 		/*
 		 * max heap order
 		 */
+		@Override
 		void percolateUp(int i) {
 			int parent;
 			while (i > 0 && self.value[self.heap[parent = (i-1) >> 1]] < self.value[self.heap[i]]) {

--- a/src/main/java/org/cicirello/ds/IntPriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/IntPriorityQueue.java
@@ -57,8 +57,11 @@ public interface IntPriorityQueue {
 	 *
 	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
 	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueue changed
+	 * as a consequence of this method call.
 	 */
-	void change(int element, int priority);
+	boolean change(int element, int priority);
 	
 	/**
 	 * Clears the IntPriorityQueue, removing all elements.

--- a/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
@@ -57,8 +57,11 @@ public interface IntPriorityQueueDouble {
 	 *
 	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
 	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueueDouble changed
+	 * as a consequence of this method call.
 	 */
-	void change(int element, double priority);
+	boolean change(int element, double priority);
 	
 	/**
 	 * Clears the IntPriorityQueueDouble, removing all elements.

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -114,8 +114,11 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 *
 	 * @param element The element whose priority is to change.
 	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueue changed
+	 * as a consequence of this method call.
 	 */
-	void change(E element, int priority);
+	boolean change(E element, int priority);
 	
 	/**
 	 * Clears the PriorityQueue, removing all elements.

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -29,13 +29,13 @@ import java.util.Queue;
 
 /**
  * <p>Interface common to the classes that provide implementations of
- * a priority queue with double valued priorities. All PriorityQueue 
+ * a priority queue with double valued priorities. All PriorityQueueDouble 
  * implementations enforce distinct elements, and use the
  * {@link Object#hashCode} and {@link Object#equals} methods to
  * to enforce distinctness, so be sure that the class of the elements
  * properly implements these methods, or else behavior is not guaranteed.</p>
  *
- * @param <E> The type of object contained in the PriorityQueue.
+ * @param <E> The type of object contained in the PriorityQueueDouble.
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
@@ -43,10 +43,10 @@ import java.util.Queue;
 public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E>> {
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority,
+	 * provided the element is not already in the PriorityQueueDouble.
 	 * This method differs from {@link #offer(Object, double)}
-	 * in that it throws an exception if the PriorityQueue contains the element,
+	 * in that it throws an exception if the PriorityQueueDouble contains the element,
 	 * while the offer method instead returns false.
 	 *
 	 * @param element The element.
@@ -64,10 +64,10 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble,
+	 * provided the element is not already in the PriorityQueueDouble.
 	 * This method differs from {@link #offer(PriorityQueueNode.Double)}
-	 * in that it throws an exception if the PriorityQueue contains the element,
+	 * in that it throws an exception if the PriorityQueueDouble contains the element,
 	 * while the offer method instead returns false.
 	 *
 	 * @param pair The (element, priority) pair to add.
@@ -85,8 +85,8 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * Adds all (element, priority) pairs from a Collection to the PriorityQueue,
-	 * provided the elements are not already in the PriorityQueue.
+	 * Adds all (element, priority) pairs from a Collection to the PriorityQueueDouble,
+	 * provided the elements are not already in the PriorityQueueDouble.
 	 * The default implementation calls the {@link #add(PriorityQueueNode.Double)} 
 	 * for each pair in the Collection. 
 	 *
@@ -94,7 +94,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	 *
 	 * @return true if the (element, priority) pairs were added.
 	 *
-	 * @throws IllegalArgumentException if the PriorityQueue already contains any
+	 * @throws IllegalArgumentException if the PriorityQueueDouble already contains any
 	 * of the (element, priority) pairs.
 	 */
 	@Override
@@ -109,40 +109,43 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	
 	/**
 	 * Changes the priority of an element if the element is
-	 * present in the PriorityQueue, and otherwise adds the
-	 * (element, priority) pair to the PriorityQueue.
+	 * present in the PriorityQueueDouble, and otherwise adds the
+	 * (element, priority) pair to the PriorityQueueDouble.
 	 *
 	 * @param element The element whose priority is to change.
 	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueueDouble changed
+	 * as a consequence of this method call.
 	 */
-	void change(E element, double priority);
+	boolean change(E element, double priority);
 	
 	/**
-	 * Clears the PriorityQueue, removing all elements.
+	 * Clears the PriorityQueueDouble, removing all elements.
 	 */
 	@Override
 	void clear();
 	
 	/**
-	 * Checks if this PriorityQueue contains a given element
+	 * Checks if this PriorityQueueDouble contains a given element
 	 * or an (element, priority) pair with a given element.
 	 *
 	 * @param o An element or (element, priority) pair to check
 	 *    for containment of the element.
 	 *
-	 * @return true if and only if this PriorityQueue contains the element.
+	 * @return true if and only if this PriorityQueueDouble contains the element.
 	 */
 	@Override
 	boolean contains(Object o);
 	
 	/**
-	 * Checks if this PriorityQueue contains all elements
+	 * Checks if this PriorityQueueDouble contains all elements
 	 * or (element, priority) pairs from a given Collection.
 	 *
 	 * @param c A Collection of elements or (element, priority) pairs to check
 	 *    for containment.
 	 *
-	 * @return true if and only if this PriorityQueue contains all of the elements
+	 * @return true if and only if this PriorityQueueDouble contains all of the elements
 	 * or (element, priority) pairs in c.
 	 */
 	@Override
@@ -154,9 +157,9 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueue,
+	 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueueDouble,
 	 * without removing it.</p>
-	 * <p>This method differs from {@link #peek()} in that if the PriorityQueue is
+	 * <p>This method differs from {@link #peek()} in that if the PriorityQueueDouble is
 	 * empty, this method throws an exception, while {@link #peek()} returns null.</p>
 	 * <p>This method serves a different purpose than {@link peekElement()}. The
 	 * {@link peekElement()} methods returns only the element of the (element, priority)
@@ -165,19 +168,19 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	 *
 	 * @return the next (element, priority) pair in priority order.
 	 *
-	 * @throws NoSuchElementException if the PriorityQueue is empty
+	 * @throws NoSuchElementException if the PriorityQueueDouble is empty
 	 */
 	@Override
 	default PriorityQueueNode.Double<E> element() {
 		PriorityQueueNode.Double<E> result = peek();
 		if (result == null) {
-			throw new NoSuchElementException("PriorityQueue is empty");
+			throw new NoSuchElementException("PriorityQueueDouble is empty");
 		}
 		return result;
 	}
 	
 	/**
-	 * Checks if the PriorityQueue is empty.
+	 * Checks if the PriorityQueueDouble is empty.
 	 *
 	 * @return true if and only if it is empty
 	 */
@@ -195,31 +198,31 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	Iterator<PriorityQueueNode.Double<E>> iterator();
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority,
+	 * provided the element is not already in the PriorityQueueDouble.
 	 *
 	 * @param element The element.
 	 * @param priority The priority of the element.
 	 *
 	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueue already contained the element.
+	 * PriorityQueueDouble already contained the element.
 	 */
 	boolean offer(E element, double priority);
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble,
+	 * provided the element is not already in the PriorityQueueDouble.
 	 *
 	 * @param pair The (element, priority) pair to add.
 	 *
 	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueue already contained the element.
+	 * PriorityQueueDouble already contained the element.
 	 */
 	@Override
 	boolean offer(PriorityQueueNode.Double<E> pair);
 	
 	/**
-	 * Gets the next (element, priority) pair in priority order from this PriorityQueue,
+	 * Gets the next (element, priority) pair in priority order from this PriorityQueueDouble,
 	 * without removing it.
 	 *
 	 * @return the next (element, priority) pair in priority order, or null if empty.
@@ -228,14 +231,14 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	PriorityQueueNode.Double<E> peek();
 	
 	/**
-	 * Gets the priority of the next element in priority order in the PriorityQueue.
+	 * Gets the priority of the next element in priority order in the PriorityQueueDouble.
 	 *
 	 * @return the priority of the next element in priority order.
 	 */
 	double peekPriority();
 	
 	/**
-	 * Gets the priority of a specified element if it is present in the PriorityQueue.
+	 * Gets the priority of a specified element if it is present in the PriorityQueueDouble.
 	 * This interface does not define the behavior when the element is not present.
 	 * Implementations may define the behavior when the element is not present.
 	 *
@@ -246,7 +249,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	double peekPriority(E element);
 	
 	/**
-	 * Gets the next element in priority order from this PriorityQueue,
+	 * Gets the next element in priority order from this PriorityQueueDouble,
 	 * without removing it.
 	 *
 	 * @return the next element in priority order, or null if empty.
@@ -254,7 +257,7 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	E peekElement();
 	
 	/**
-	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue.
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueueDouble.
 	 *
 	 * @return the next (element, priority) pair in priority order, or null if empty.
 	 */
@@ -262,32 +265,32 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	PriorityQueueNode.Double<E> poll();
 	
 	/**
-	 * Removes and returns the next element in priority order from this PriorityQueue.
+	 * Removes and returns the next element in priority order from this PriorityQueueDouble.
 	 *
 	 * @return the next element in priority order, or null if empty.
 	 */
 	E pollElement();
 	
 	/**
-	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue.
-	 * This method differs from {@link #poll()} in that if the PriorityQueue is
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueueDouble.
+	 * This method differs from {@link #poll()} in that if the PriorityQueueDouble is
 	 * empty, this method throws an exception, while {@link #poll()} returns null.
 	 *
 	 * @return the next (element, priority) pair in priority order.
 	 *
-	 * @throws NoSuchElementException if the PriorityQueue is empty
+	 * @throws NoSuchElementException if the PriorityQueueDouble is empty
 	 */
 	@Override
 	default PriorityQueueNode.Double<E> remove() {
 		PriorityQueueNode.Double<E> result = poll();
 		if (result == null) {
-			throw new NoSuchElementException("PriorityQueue is empty");
+			throw new NoSuchElementException("PriorityQueueDouble is empty");
 		}
 		return result;
 	}
 	
 	/**
-	 * Removes from this PriorityQueue the (element, priority) pair, if present, 
+	 * Removes from this PriorityQueueDouble the (element, priority) pair, if present, 
 	 * for a specified element or element from a specified (element, priority) pair.
 	 *
 	 * @param o An element or (element, priority) pair, such that element designates
@@ -301,13 +304,13 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	boolean remove(Object o);
 	
 	/**
-	 * Removes from this PriorityQueue all (element, priority) pairs
+	 * Removes from this PriorityQueueDouble all (element, priority) pairs
 	 * such that a given Collection c either contains the element or
 	 * contains an (element, priority) pair with the same element.
 	 *
 	 * @param c A Collection of elements or (element, priority) pairs for removal.
 	 *
-	 * @return true if and only if this PriorityQueue changed as a result of this method.
+	 * @return true if and only if this PriorityQueueDouble changed as a result of this method.
 	 */
 	@Override
 	default boolean removeAll(Collection<?> c) {
@@ -321,63 +324,63 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * Removes and returns the next element in priority order from this PriorityQueue.
-	 * This method differs from {@link #pollElement()} in that if the PriorityQueue is
+	 * Removes and returns the next element in priority order from this PriorityQueueDouble.
+	 * This method differs from {@link #pollElement()} in that if the PriorityQueueDouble is
 	 * empty, this method throws an exception, while {@link #pollElement()} returns null.
 	 *
 	 * @return the next element in priority order.
 	 *
-	 * @throws NoSuchElementException if the PriorityQueue is empty
+	 * @throws NoSuchElementException if the PriorityQueueDouble is empty
 	 */
 	default E removeElement() {
 		E result = pollElement();
 		if (result == null) {
-			throw new NoSuchElementException("PriorityQueue is empty");
+			throw new NoSuchElementException("PriorityQueueDouble is empty");
 		}
 		return result;
 	}
 	
 	/**
-	 * Removes from this PriorityQueue all (element, priority) pairs
+	 * Removes from this PriorityQueueDouble all (element, priority) pairs
 	 * except for the elements or (element, priority) pairs contained in a 
 	 * given Collection c.
 	 *
 	 * @param c A Collection of elements or (element, priority) pairs to keep.
 	 *
-	 * @return true if and only if this PriorityQueue changed as a result of this method.
+	 * @return true if and only if this PriorityQueueDouble changed as a result of this method.
 	 */
 	@Override
 	boolean retainAll(Collection<?> c);
 	
 	/**
-	 * Gets the current size of the PriorityQueue, which is the
+	 * Gets the current size of the PriorityQueueDouble, which is the
 	 * number of (element, value) pairs that it contains.
 	 *
-	 * @return the current size of the PriorityQueue.
+	 * @return the current size of the PriorityQueueDouble.
 	 */
 	@Override
 	int size();
 	
 	/**
 	 * Returns an array containing all of the (element, priority) pairs contained in the
-	 * PriorityQueue. The order is not guaranteed. The runtime component type is Object.
-	 * The PriorityQueue does not maintain any references to the array that is returned,
+	 * PriorityQueueDouble. The order is not guaranteed. The runtime component type is Object.
+	 * The PriorityQueueDouble does not maintain any references to the array that is returned,
 	 * instead creating a new array upon each call to the toArray method. The length of the
-	 * array that is returned is equal to the current {@link #size()} of the PriorityQueue.
+	 * array that is returned is equal to the current {@link #size()} of the PriorityQueueDouble.
 	 *
 	 * @return an array, whose runtime component type is Object, containing all of the 
-	 * (element, priority) pairs currently in the PriorityQueue.
+	 * (element, priority) pairs currently in the PriorityQueueDouble.
 	 */
 	@Override
 	Object[] toArray();
 	
 	/**
 	 * Returns an array containing all of the (element, priority) pairs contained in the
-	 * PriorityQueue. The order is not guaranteed. The runtime component type is the same
+	 * PriorityQueueDouble. The order is not guaranteed. The runtime component type is the same
 	 * as the array passed to it as a parameter. If the specified array is large enough,
 	 * then it is used, otherwise a new array is allocated whose length is equal to 
-	 * the current {@link #size()} of the PriorityQueue. If the specified array is larger
-	 * than the current size() of the PriorityQueue, the first extra cell is set to null.
+	 * the current {@link #size()} of the PriorityQueueDouble. If the specified array is larger
+	 * than the current size() of the PriorityQueueDouble, the first extra cell is set to null.
 	 *
 	 * @param array The array in which to place the (element, priority) pairs, if it is
 	 * sufficiently large, otherwise a new array of length {@link #size()} is allocated of

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -494,7 +494,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 1);
+			assertTrue(pq.change(elements[i], 1));
 			assertEquals(1.0, pq.peekPriority(elements[i]), 0.0);
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -510,7 +510,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 100);
+			assertTrue(pq.change(elements[i], 100));
 			assertEquals(100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -528,7 +528,7 @@ public class BinaryHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], p);
+				assertTrue(pq.change(elements[i], p));
 				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -555,7 +555,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -569,7 +569,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", p);
+			assertTrue(pq.change("YYY", p));
 			assertEquals(p, pq.peekPriority("YYY"), 0.0);
 			int j = 0;
 			for (; j < n; j++) {
@@ -1108,7 +1108,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -1);
+			assertTrue(pq.change(elements[i], -1));
 			assertEquals(-1.0, pq.peekPriority(elements[i]), 0.0);
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -1124,7 +1124,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -100);
+			assertTrue(pq.change(elements[i], -100));
 			assertEquals(-100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -1142,7 +1142,7 @@ public class BinaryHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], -p);
+				assertTrue(pq.change(elements[i], -p));
 				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -1169,7 +1169,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -1183,7 +1183,7 @@ public class BinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", -p);
+			assertTrue(pq.change("YYY", -p));
 			assertEquals(-p, pq.peekPriority("YYY"), 0.0);
 			int j = 0;
 			for (; j < n; j++) {

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -495,7 +495,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 1);
+			assertTrue(pq.change(elements[i], 1));
 			assertEquals(1, pq.peekPriority(elements[i]));
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -511,7 +511,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 100);
+			assertTrue(pq.change(elements[i], 100));
 			assertEquals(100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -529,7 +529,7 @@ public class BinaryHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], p);
+				assertTrue(pq.change(elements[i], p));
 				assertEquals(p, pq.peekPriority(elements[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -556,7 +556,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -570,7 +570,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", p);
+			assertTrue(pq.change("YYY", p));
 			assertEquals(p, pq.peekPriority("YYY"));
 			int j = 0;
 			for (; j < n; j++) {
@@ -1109,7 +1109,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -1);
+			assertTrue(pq.change(elements[i], -1));
 			assertEquals(-1, pq.peekPriority(elements[i]));
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -1125,7 +1125,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -100);
+			assertTrue(pq.change(elements[i], -100));
 			assertEquals(-100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -1143,7 +1143,7 @@ public class BinaryHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], -p);
+				assertTrue(pq.change(elements[i], -p));
 				assertEquals(-p, pq.peekPriority(elements[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -1170,7 +1170,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -1184,7 +1184,7 @@ public class BinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", -p);
+			assertTrue(pq.change("YYY", -p));
 			assertEquals(-p, pq.peekPriority("YYY"));
 			int j = 0;
 			for (; j < n; j++) {

--- a/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
@@ -522,12 +522,12 @@ public class FibonacciHeapDoubleTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], -1);
+						assertTrue(pq.change(elements[i], -1));
 						assertEquals(-1.0, pq.peekPriority(elements[i]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], -2);
+						assertTrue(pq.change(elements[k], -2));
 						assertEquals(-2.0, pq.peekPriority(elements[k]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
@@ -597,12 +597,12 @@ public class FibonacciHeapDoubleTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], 95);
+						assertTrue(pq.change(elements[i], 95));
 						assertEquals(95.0, pq.peekPriority(elements[i]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], 102);
+						assertTrue(pq.change(elements[k], 102));
 						assertEquals(102.0, pq.peekPriority(elements[k]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
@@ -644,7 +644,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 1);
+			assertTrue(pq.change(elements[i], 1));
 			assertEquals(1.0, pq.peekPriority(elements[i]), 0.0);
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -660,7 +660,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 100);
+			assertTrue(pq.change(elements[i], 100));
 			assertEquals(100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -678,7 +678,7 @@ public class FibonacciHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], p);
+				assertTrue(pq.change(elements[i], p));
 				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -705,7 +705,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -719,7 +719,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", p);
+			assertTrue(pq.change("YYY", p));
 			assertEquals(p, pq.peekPriority("YYY"), 0.0);
 			int j = 0;
 			for (; j < n; j++) {
@@ -745,7 +745,7 @@ public class FibonacciHeapDoubleTests {
 			}
 			String minElement = pq.pollElement();
 			if (!minElement.equals(elements[i])) {
-				pq.change(elements[i], priorities[i]-0.5);
+				assertTrue(pq.change(elements[i], priorities[i]-0.5));
 				assertEquals(priorities[i]-0.5, pq.peekPriority(elements[i]), 0.0);
 			}
 			for (int j = 0; j < n; j++) {
@@ -1176,12 +1176,12 @@ public class FibonacciHeapDoubleTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], 2);
+						assertTrue(pq.change(elements[i], 2));
 						assertEquals(2.0, pq.peekPriority(elements[i]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], 1);
+						assertTrue(pq.change(elements[k], 1));
 						assertEquals(1.0, pq.peekPriority(elements[k]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
@@ -1251,12 +1251,12 @@ public class FibonacciHeapDoubleTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], -102);
+						assertTrue(pq.change(elements[i], -102));
 						assertEquals(-102.0, pq.peekPriority(elements[i]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], -95);
+						assertTrue(pq.change(elements[k], -95));
 						assertEquals(-95.0, pq.peekPriority(elements[k]), 0.0);
 						assertEquals(n-3, pq.size());
 					}
@@ -1298,7 +1298,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -1);
+			assertTrue(pq.change(elements[i], -1));
 			assertEquals(-1.0, pq.peekPriority(elements[i]), 0.0);
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -1314,7 +1314,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -100);
+			assertTrue(pq.change(elements[i], -100));
 			assertEquals(-100.0, pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -1332,7 +1332,7 @@ public class FibonacciHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], -p);
+				assertTrue(pq.change(elements[i], -p));
 				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -1359,7 +1359,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -1373,7 +1373,7 @@ public class FibonacciHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", -p);
+			assertTrue(pq.change("YYY", -p));
 			assertEquals(-p, pq.peekPriority("YYY"), 0.0);
 			int j = 0;
 			for (; j < n; j++) {
@@ -1399,7 +1399,7 @@ public class FibonacciHeapDoubleTests {
 			}
 			String maxElement = pq.pollElement();
 			if (!maxElement.equals(elements[i])) {
-				pq.change(elements[i], priorities[i]+0.5);
+				assertTrue(pq.change(elements[i], priorities[i]+0.5));
 				assertEquals(priorities[i]+0.5, pq.peekPriority(elements[i]), 0.0);
 			}
 			for (int j = 0; j < n; j++) {

--- a/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
@@ -523,12 +523,12 @@ public class FibonacciHeapTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], -1);
+						assertTrue(pq.change(elements[i], -1));
 						assertEquals(-1, pq.peekPriority(elements[i]));
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], -2);
+						assertTrue(pq.change(elements[k], -2));
 						assertEquals(-2, pq.peekPriority(elements[k]));
 						assertEquals(n-3, pq.size());
 					}
@@ -598,12 +598,12 @@ public class FibonacciHeapTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], 95);
+						assertTrue(pq.change(elements[i], 95));
 						assertEquals(95, pq.peekPriority(elements[i]));
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], 102);
+						assertTrue(pq.change(elements[k], 102));
 						assertEquals(102, pq.peekPriority(elements[k]));
 						assertEquals(n-3, pq.size());
 					}
@@ -645,7 +645,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 1);
+			assertTrue(pq.change(elements[i], 1));
 			assertEquals(1, pq.peekPriority(elements[i]));
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -661,7 +661,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], 100);
+			assertTrue(pq.change(elements[i], 100));
 			assertEquals(100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -679,7 +679,7 @@ public class FibonacciHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], p);
+				assertTrue(pq.change(elements[i], p));
 				assertEquals(p, pq.peekPriority(elements[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -706,7 +706,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -720,7 +720,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", p);
+			assertTrue(pq.change("YYY", p));
 			assertEquals(p, pq.peekPriority("YYY"));
 			int j = 0;
 			for (; j < n; j++) {
@@ -746,7 +746,7 @@ public class FibonacciHeapTests {
 			}
 			String minElement = pq.pollElement();
 			if (!minElement.equals(elements[i])) {
-				pq.change(elements[i], priorities[i]-1);
+				assertTrue(pq.change(elements[i], priorities[i]-1));
 				assertEquals(priorities[i]-1, pq.peekPriority(elements[i]));
 			}
 			for (int j = 0; j < n; j++) {
@@ -1177,12 +1177,12 @@ public class FibonacciHeapTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], 2);
+						assertTrue(pq.change(elements[i], 2));
 						assertEquals(2, pq.peekPriority(elements[i]));
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], 1);
+						assertTrue(pq.change(elements[k], 1));
 						assertEquals(1, pq.peekPriority(elements[k]));
 						assertEquals(n-3, pq.size());
 					}
@@ -1252,12 +1252,12 @@ public class FibonacciHeapTests {
 					assertEquals("T", e3);
 					assertEquals(n-3, pq.size());
 					if (!e1.equals(elements[i]) && !e2.equals(elements[i]) && !e3.equals(elements[i])) {
-						pq.change(elements[i], -102);
+						assertTrue(pq.change(elements[i], -102));
 						assertEquals(-102, pq.peekPriority(elements[i]));
 						assertEquals(n-3, pq.size());
 					}
 					if (!e1.equals(elements[k]) && !e2.equals(elements[k]) && !e3.equals(elements[k])) {
-						pq.change(elements[k], -95);
+						assertTrue(pq.change(elements[k], -95));
 						assertEquals(-95, pq.peekPriority(elements[k]));
 						assertEquals(n-3, pq.size());
 					}
@@ -1299,7 +1299,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -1);
+			assertTrue(pq.change(elements[i], -1));
 			assertEquals(-1, pq.peekPriority(elements[i]));
 			assertEquals(elements[i], pq.pollElement());
 			for (int j = 0; j < n; j++) {
@@ -1315,7 +1315,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], -100);
+			assertTrue(pq.change(elements[i], -100));
 			assertEquals(-100, pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -1333,7 +1333,7 @@ public class FibonacciHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(elements[j], priorities[j]);
 				}
-				pq.change(elements[i], -p);
+				assertTrue(pq.change(elements[i], -p));
 				assertEquals(-p, pq.peekPriority(elements[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -1360,7 +1360,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change(elements[i], priorities[i]);
+			assertFalse(pq.change(elements[i], priorities[i]));
 			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(elements[j], pq.pollElement());
@@ -1374,7 +1374,7 @@ public class FibonacciHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(elements[j], priorities[j]);
 			}
-			pq.change("YYY", -p);
+			assertTrue(pq.change("YYY", -p));
 			assertEquals(-p, pq.peekPriority("YYY"));
 			int j = 0;
 			for (; j < n; j++) {
@@ -1400,7 +1400,7 @@ public class FibonacciHeapTests {
 			}
 			String maxElement = pq.pollElement();
 			if (!maxElement.equals(elements[i])) {
-				pq.change(elements[i], priorities[i]+1);
+				assertTrue(pq.change(elements[i], priorities[i]+1));
 				assertEquals(priorities[i]+1, pq.peekPriority(elements[i]));
 			}
 			for (int j = 0; j < n; j++) {

--- a/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
@@ -244,7 +244,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], 1);
+			assertTrue(pq.change(e[i], 1));
 			assertEquals(1, pq.peekPriority(e[i]), 0.0);
 			assertEquals(e[i], pq.poll());
 			for (int j = 0; j < n; j++) {
@@ -260,7 +260,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], 100);
+			assertTrue(pq.change(e[i], 100));
 			assertEquals(100, pq.peekPriority(e[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -278,7 +278,7 @@ public class IntBinaryHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(e[j], p[j]);
 				}
-				pq.change(e[i], pNew);
+				assertTrue(pq.change(e[i], pNew));
 				assertEquals(pNew, pq.peekPriority(e[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -305,7 +305,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], p[i]);
+			assertFalse(pq.change(e[i], p[i]));
 			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(e[j], pq.poll());
@@ -319,7 +319,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n-1; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[n-1], pNew);
+			assertTrue(pq.change(e[n-1], pNew));
 			assertEquals(pNew, pq.peekPriority(e[n-1]), 0.0);
 			int j = 0;
 			for (; j < n-1; j++) {
@@ -486,7 +486,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], -1);
+			assertTrue(pq.change(e[i], -1));
 			assertEquals(-1, pq.peekPriority(e[i]), 0.0);
 			assertEquals(e[i], pq.poll());
 			for (int j = 0; j < n; j++) {
@@ -502,7 +502,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], -100);
+			assertTrue(pq.change(e[i], -100));
 			assertEquals(-100, pq.peekPriority(e[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -520,7 +520,7 @@ public class IntBinaryHeapDoubleTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(e[j], p[j]);
 				}
-				pq.change(e[i], -pNew);
+				assertTrue(pq.change(e[i], -pNew));
 				assertEquals(-pNew, pq.peekPriority(e[i]), 0.0);
 				int j = 0;
 				for (; j < n; j++) {
@@ -547,7 +547,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], p[i]);
+			assertFalse(pq.change(e[i], p[i]));
 			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
 			for (int j = 0; j < n; j++) {
 				assertEquals(e[j], pq.poll());
@@ -561,7 +561,7 @@ public class IntBinaryHeapDoubleTests {
 			for (int j = 0; j < n-1; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[n-1], -pNew);
+			assertTrue(pq.change(e[n-1], -pNew));
 			assertEquals(-pNew, pq.peekPriority(e[n-1]), 0.0);
 			int j = 0;
 			for (; j < n-1; j++) {

--- a/src/test/java/org/cicirello/ds/IntBinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/IntBinaryHeapTests.java
@@ -244,7 +244,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], 1);
+			assertTrue(pq.change(e[i], 1));
 			assertEquals(1, pq.peekPriority(e[i]));
 			assertEquals(e[i], pq.poll());
 			for (int j = 0; j < n; j++) {
@@ -260,7 +260,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], 100);
+			assertTrue(pq.change(e[i], 100));
 			assertEquals(100, pq.peekPriority(e[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -278,7 +278,7 @@ public class IntBinaryHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(e[j], p[j]);
 				}
-				pq.change(e[i], pNew);
+				assertTrue(pq.change(e[i], pNew));
 				assertEquals(pNew, pq.peekPriority(e[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -305,7 +305,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], p[i]);
+			assertFalse(pq.change(e[i], p[i]));
 			assertEquals(p[i], pq.peekPriority(e[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(e[j], pq.poll());
@@ -319,7 +319,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n-1; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[n-1], pNew);
+			assertTrue(pq.change(e[n-1], pNew));
 			assertEquals(pNew, pq.peekPriority(e[n-1]));
 			int j = 0;
 			for (; j < n-1; j++) {
@@ -486,7 +486,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], -1);
+			assertTrue(pq.change(e[i], -1));
 			assertEquals(-1, pq.peekPriority(e[i]));
 			assertEquals(e[i], pq.poll());
 			for (int j = 0; j < n; j++) {
@@ -502,7 +502,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], -100);
+			assertTrue(pq.change(e[i], -100));
 			assertEquals(-100, pq.peekPriority(e[i]));
 			for (int j = 0; j < n; j++) {
 				if (i!=j) {
@@ -520,7 +520,7 @@ public class IntBinaryHeapTests {
 				for (int j = 0; j < n; j++) {
 					pq.offer(e[j], p[j]);
 				}
-				pq.change(e[i], -pNew);
+				assertTrue(pq.change(e[i], -pNew));
 				assertEquals(-pNew, pq.peekPriority(e[i]));
 				int j = 0;
 				for (; j < n; j++) {
@@ -547,7 +547,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[i], p[i]);
+			assertFalse(pq.change(e[i], p[i]));
 			assertEquals(p[i], pq.peekPriority(e[i]));
 			for (int j = 0; j < n; j++) {
 				assertEquals(e[j], pq.poll());
@@ -561,7 +561,7 @@ public class IntBinaryHeapTests {
 			for (int j = 0; j < n-1; j++) {
 				pq.offer(e[j], p[j]);
 			}
-			pq.change(e[n-1], -pNew);
+			assertTrue(pq.change(e[n-1], -pNew));
 			assertEquals(-pNew, pq.peekPriority(e[n-1]));
 			int j = 0;
 			for (; j < n-1; j++) {


### PR DESCRIPTION
## Summary
Modified the change method of the PriorityQueue, PriorityQueueDouble, IntPriorityQueue, IntPriorityQueueDouble  interfaces, and of the classes that implement them to now return a boolean. This is technically a breaking change, but not going to increment major release number because these interfaces were just introduced, and I believe my own projects are the only ones using this library at the present time, and even those haven't upgraded to the version where these interfaces were introduced. Additionally, it is only a breaking change if someone is implementing the interfaces. If they are simply using the library's implementations, then the change of return type from void to boolean will have no effect on code using the implementations.

## Closing Issues
Closes #48 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
