### PR TITLE
Added promote and demote methods to priority queue interfaces and classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * FibonacciHeap: implements PriorityQueue with a Fibonacci heap for both min-heap and max-heap cases.
 * FibonacciHeapDouble: implements PriorityQueueDouble with a Fibonacci heap for both min-heap and max-heap cases.
+* Added promote and demote methods to the PriorityQueue, PriorityQueueDouble, IntPriorityQueue, IntPriorityQueueDouble
+  interfaces for changing priorities strictly in one direction, and implemented in the various heap classes.
 
 ### Changed
 * The change method of the PriorityQueue, PriorityQueueDouble, IntPriorityQueue, IntPriorityQueueDouble

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -302,6 +302,20 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 		return index.containsKey(o);
 	}
 	
+	@Override
+	public final boolean demote(E element, int priority) {
+		Integer where = index.get(element);
+		if (where != null) { 
+			int i = where;
+			if (compare.belongsAbove(buffer[i].value, priority)) {
+				buffer[i].value = priority;
+				percolateDown(i);
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	/**
 	 * Increases the capacity if the capacity is not
 	 * already at least the specified minimum. If the capacity
@@ -430,6 +444,20 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 		} else {
 			return null;
 		}
+	}
+	
+	@Override
+	public final boolean promote(E element, int priority) {
+		Integer where = index.get(element);
+		if (where != null) { 
+			int i = where;
+			if (compare.belongsAbove(priority, buffer[i].value)) {
+				buffer[i].value = priority;
+				percolateUp(i);
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -302,6 +302,20 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 		return index.containsKey(o);
 	}
 	
+	@Override
+	public final boolean demote(E element, double priority) {
+		Integer where = index.get(element);
+		if (where != null) { 
+			int i = where;
+			if (compare.belongsAbove(buffer[i].value, priority)) {
+				buffer[i].value = priority;
+				percolateDown(i);
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	/**
 	 * Increases the capacity if the capacity is not
 	 * already at least the specified minimum. If the capacity
@@ -430,6 +444,20 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 		} else {
 			return null;
 		}
+	}
+	
+	@Override
+	public final boolean promote(E element, double priority) {
+		Integer where = index.get(element);
+		if (where != null) { 
+			int i = where;
+			if (compare.belongsAbove(priority, buffer[i].value)) {
+				buffer[i].value = priority;
+				percolateUp(i);
+				return true;
+			}
+		}
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/FibonacciHeap.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeap.java
@@ -269,6 +269,16 @@ public final class FibonacciHeap<E> implements PriorityQueue<E>, Copyable<Fibona
 		return index.containsKey(o);
 	}
 	
+	@Override
+	public final boolean demote(E element, int priority) {
+		Node<E> node = index.get(element);
+		if (node != null && compare.comesBefore(node.e.value, priority)) {
+			internalDemote(node, priority);
+			return true;
+		}
+		return false;
+	}
+	
 	/**
 	 * Checks if this FibonacciHeap contains the same (element, priority)
 	 * pairs as another FibonacciHeap, including the specific structure
@@ -391,6 +401,16 @@ public final class FibonacciHeap<E> implements PriorityQueue<E>, Copyable<Fibona
 			return z.e;
 		}
 		return null;
+	}
+	
+	@Override
+	public final boolean promote(E element, int priority) {
+		Node<E> node = index.get(element);
+		if (node != null && compare.comesBefore(priority, node.e.value)) {
+			internalPromote(node, priority);
+			return true;
+		}
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
@@ -269,6 +269,16 @@ public final class FibonacciHeapDouble<E> implements PriorityQueueDouble<E>, Cop
 		return index.containsKey(o);
 	}
 	
+	@Override
+	public final boolean demote(E element, double priority) {
+		Node<E> node = index.get(element);
+		if (node != null && compare.comesBefore(node.e.value, priority)) {
+			internalDemote(node, priority);
+			return true;
+		}
+		return false;
+	}
+	
 	/**
 	 * Checks if this FibonacciHeapDouble contains the same (element, priority)
 	 * pairs as another FibonacciHeapDouble, including the specific structure
@@ -391,6 +401,16 @@ public final class FibonacciHeapDouble<E> implements PriorityQueueDouble<E>, Cop
 			return z.e;
 		}
 		return null;
+	}
+	
+	@Override
+	public final boolean promote(E element, double priority) {
+		Node<E> node = index.get(element);
+		if (node != null && compare.comesBefore(priority, node.e.value)) {
+			internalPromote(node, priority);
+			return true;
+		}
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/IntBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeap.java
@@ -120,10 +120,7 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 	 */
 	@Override
 	public final boolean change(int element, int priority) {
-		if (!offer(element, priority)) {
-			return internalChange(element, priority);
-		}
-		return true;
+		return offer(element, priority) || internalPromote(element, priority) || internalDemote(element, priority);
 	}
 	
 	@Override
@@ -173,6 +170,17 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 			throw new IllegalArgumentException("domain must be positive");
 		}
 		return new IntBinaryHeap(n);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean demote(int element, int priority) {
+		return in[element] && internalDemote(element, priority);
 	}
 	
 	@Override
@@ -237,6 +245,17 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 		return min;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean promote(int element, int priority) {
+		return in[element] && internalPromote(element, priority);
+	}
+	
 	@Override
 	public final int size() {
 		return size;
@@ -246,12 +265,21 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 	 * package-private to enable overriding in 
 	 * nested subclass to support max heaps.
 	 */
-	boolean internalChange(int element, int priority) {
+	boolean internalPromote(int element, int priority) {
 		if (priority < value[element]) {
 			value[element] = priority;
 			percolateUp(index[element]);
 			return true;
-		} else if (priority > value[element]) {
+		}
+		return false;
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	boolean internalDemote(int element, int priority) {
+		if (priority > value[element]) {
 			value[element] = priority;
 			percolateDown(index[element]);
 			return true;
@@ -325,12 +353,21 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 		 * max heap order
 		 */
 		@Override
-		boolean internalChange(int element, int priority) {
+		boolean internalPromote(int element, int priority) {
 			if (priority > self.value[element]) {
 				self.value[element] = priority;
 				percolateUp(self.index[element]);
 				return true;
-			} else if (priority < self.value[element]) {
+			}
+			return false;
+		}
+		
+		/*
+		 * max heap order
+		 */
+		@Override
+		boolean internalDemote(int element, int priority) {
+			if (priority < self.value[element]) {
 				self.value[element] = priority;
 				percolateDown(self.index[element]);
 				return true;

--- a/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
@@ -120,10 +120,7 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 	 */
 	@Override
 	public final boolean change(int element, double priority) {
-		if (!offer(element, priority)) {
-			return internalChange(element, priority);
-		}
-		return true;
+		return offer(element, priority) || internalPromote(element, priority) || internalDemote(element, priority);
 	}
 	
 	@Override
@@ -173,6 +170,17 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 			throw new IllegalArgumentException("domain must be positive");
 		}
 		return new IntBinaryHeapDouble(n);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean demote(int element, double priority) {
+		return in[element] && internalDemote(element, priority);
 	}
 	
 	@Override
@@ -237,6 +245,17 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 		return min;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 */
+	@Override
+	public final boolean promote(int element, double priority) {
+		return in[element] && internalPromote(element, priority);
+	}
+	
 	@Override
 	public final int size() {
 		return size;
@@ -246,12 +265,21 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 	 * package-private to enable overriding in 
 	 * nested subclass to support max heaps.
 	 */
-	boolean internalChange(int element, double priority) {
+	boolean internalPromote(int element, double priority) {
 		if (priority < value[element]) {
 			value[element] = priority;
 			percolateUp(index[element]);
 			return true;
-		} else if (priority > value[element]) {
+		}
+		return false;
+	}
+	
+	/*
+	 * package-private to enable overriding in 
+	 * nested subclass to support max heaps.
+	 */
+	boolean internalDemote(int element, double priority) {
+		if (priority > value[element]) {
 			value[element] = priority;
 			percolateDown(index[element]);
 			return true;
@@ -325,12 +353,21 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 		 * max heap order
 		 */
 		@Override
-		boolean internalChange(int element, double priority) {
+		boolean internalPromote(int element, double priority) {
 			if (priority > self.value[element]) {
 				self.value[element] = priority;
 				percolateUp(self.index[element]);
 				return true;
-			} else if (priority < self.value[element]) {
+			}
+			return false;
+		}
+		
+		/*
+		 * max heap order
+		 */
+		@Override
+		boolean internalDemote(int element, double priority) {
+			if (priority < self.value[element]) {
 				self.value[element] = priority;
 				percolateDown(self.index[element]);
 				return true;

--- a/src/main/java/org/cicirello/ds/IntPriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/IntPriorityQueue.java
@@ -82,6 +82,24 @@ public interface IntPriorityQueue {
 	boolean contains(int element);
 	
 	/**
+	 * Demotes an element relative to priority order if the element is
+	 * present in the IntPriorityQueue. For a min-heap, demotion means
+	 * increasing the element's priority, while for a max-heap, demotion
+	 * means decreasing its priority. If the element is not in the IntPriorityQueue,
+	 * or if its new priority is not a demotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueue changed
+	 * as a consequence of this method call.
+	 */
+	boolean demote(int element, int priority);
+	
+	/**
 	 * Returns the domain of this IntPriorityQueue. Note that the domain
 	 * is not the same thing as the size. The domain defines the elements
 	 * that are allowed in the IntPriorityQueue, whether or not they actually appear within it.
@@ -148,6 +166,24 @@ public interface IntPriorityQueue {
 	 * @return the next element in priority order.
 	 */
 	int poll();
+	
+	/**
+	 * Promotes an element relative to priority order if the element is
+	 * present in the IntPriorityQueue. For a min-heap, promotion means
+	 * decreasing the element's priority, while for a max-heap, promotion
+	 * means increasing its priority. If the element is not in the IntPriorityQueue,
+	 * or if its new priority is not a promotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueue changed
+	 * as a consequence of this method call.
+	 */
+	boolean promote(int element, int priority);
 	
 	/**
 	 * Gets the current size of the IntPriorityQueue, which is the

--- a/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/IntPriorityQueueDouble.java
@@ -82,6 +82,24 @@ public interface IntPriorityQueueDouble {
 	boolean contains(int element);
 	
 	/**
+	 * Demotes an element relative to priority order if the element is
+	 * present in the IntPriorityQueueDouble. For a min-heap, demotion means
+	 * increasing the element's priority, while for a max-heap, demotion
+	 * means decreasing its priority. If the element is not in the IntPriorityQueueDouble,
+	 * or if its new priority is not a demotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueueDouble changed
+	 * as a consequence of this method call.
+	 */
+	boolean demote(int element, double priority);
+	
+	/**
 	 * Returns the domain of this IntPriorityQueueDouble. Note that the domain
 	 * is not the same thing as the size. The domain defines the elements
 	 * that are allowed in the IntPriorityQueueDouble, whether or not they actually appear within it.
@@ -148,6 +166,24 @@ public interface IntPriorityQueueDouble {
 	 * @return the next element in priority order.
 	 */
 	int poll();
+	
+	/**
+	 * Promotes an element relative to priority order if the element is
+	 * present in the IntPriorityQueueDouble. For a min-heap, promotion means
+	 * decreasing the element's priority, while for a max-heap, promotion
+	 * means increasing its priority. If the element is not in the IntPriorityQueueDouble,
+	 * or if its new priority is not a promotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @throws IndexOutOfBoundsException if element is negative, or if element is greater than
+	 *     or equal to the domain n.
+	 *
+	 * @return true if and only if the IntPriorityQueueDouble changed
+	 * as a consequence of this method call.
+	 */
+	boolean promote(int element, double priority);
 	
 	/**
 	 * Gets the current size of the IntPriorityQueueDouble, which is the

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -157,6 +157,21 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	}
 	
 	/**
+	 * Demotes an element relative to priority order if the element is
+	 * present in the PriorityQueue. For a min-heap, demotion means
+	 * increasing the element's priority, while for a max-heap, demotion
+	 * means decreasing its priority. If the element is not in the PriorityQueue,
+	 * or if its new priority is not a demotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueue changed
+	 * as a consequence of this method call.
+	 */
+	boolean demote(E element, int priority);
+	
+	/**
 	 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueue,
 	 * without removing it.</p>
 	 * <p>This method differs from {@link #peek()} in that if the PriorityQueue is
@@ -270,6 +285,21 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	 * @return the next element in priority order, or null if empty.
 	 */
 	E pollElement();
+	
+	/**
+	 * Promotes an element relative to priority order if the element is
+	 * present in the PriorityQueue. For a min-heap, promotion means
+	 * decreasing the element's priority, while for a max-heap, promotion
+	 * means increasing its priority. If the element is not in the PriorityQueue,
+	 * or if its new priority is not a promotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueue changed
+	 * as a consequence of this method call.
+	 */
+	boolean promote(E element, int priority);
 	
 	/**
 	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue.

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -157,6 +157,21 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
+	 * Demotes an element relative to priority order if the element is
+	 * present in the PriorityQueueDouble. For a min-heap, demotion means
+	 * increasing the element's priority, while for a max-heap, demotion
+	 * means decreasing its priority. If the element is not in the PriorityQueueDouble,
+	 * or if its new priority is not a demotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueueDouble changed
+	 * as a consequence of this method call.
+	 */
+	boolean demote(E element, double priority);
+	
+	/**
 	 * <p>Gets the next (element, priority) pair in priority order from this PriorityQueueDouble,
 	 * without removing it.</p>
 	 * <p>This method differs from {@link #peek()} in that if the PriorityQueueDouble is
@@ -270,6 +285,21 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	 * @return the next element in priority order, or null if empty.
 	 */
 	E pollElement();
+	
+	/**
+	 * Promotes an element relative to priority order if the element is
+	 * present in the PriorityQueueDouble. For a min-heap, promotion means
+	 * decreasing the element's priority, while for a max-heap, promotion
+	 * means increasing its priority. If the element is not in the PriorityQueueDouble,
+	 * or if its new priority is not a promotion, then this method does nothing.
+	 *
+	 * @param element The element whose priority is to change.
+	 * @param priority Its new priority.
+	 *
+	 * @return true if and only if the PriorityQueueDouble changed
+	 * as a consequence of this method call.
+	 */
+	boolean promote(E element, double priority);
 	
 	/**
 	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueueDouble.

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -590,6 +590,112 @@ public class BinaryHeapDoubleTests {
 	}
 	
 	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], 1));
+			assertEquals(1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], 100));
+			assertEquals(100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (p < priorities[i]) {
+					assertTrue(pq.promote(elements[i], p));
+				} else {
+					assertTrue(pq.demote(elements[i], p));
+				}
+				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
 	public void testDefaultMinHeap() {
 		int n = 31;
 		String[] elements = createStrings(n);
@@ -1198,6 +1304,112 @@ public class BinaryHeapDoubleTests {
 				if (priorities[j] < -p) {
 					assertEquals(elements[j], pq.pollElement());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], -1));
+			assertEquals(-1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], -100));
+			assertEquals(-100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (-p > priorities[i]) {
+					assertTrue(pq.promote(elements[i], -p));
+				} else {
+					assertTrue(pq.demote(elements[i], -p));
+				}
+				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			BinaryHeapDouble<String> pq = BinaryHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -591,6 +591,112 @@ public class BinaryHeapTests {
 	}
 	
 	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], 1));
+			assertEquals(1, pq.peekPriority(elements[i]));
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], 100));
+			assertEquals(100, pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (p < priorities[i]) {
+					assertTrue(pq.promote(elements[i], p));
+				} else {
+					assertTrue(pq.demote(elements[i], p));
+				}
+				assertEquals(p, pq.peekPriority(elements[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
 	public void testDefaultMinHeap() {
 		int n = 31;
 		String[] elements = createStrings(n);
@@ -1199,6 +1305,112 @@ public class BinaryHeapTests {
 				if (priorities[j] < -p) {
 					assertEquals(elements[j], pq.pollElement());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], -1));
+			assertEquals(-1, pq.peekPriority(elements[i]));
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], -100));
+			assertEquals(-100, pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (-p > priorities[i]) {
+					assertTrue(pq.promote(elements[i], -p));
+				} else {
+					assertTrue(pq.demote(elements[i], -p));
+				}
+				assertEquals(-p, pq.peekPriority(elements[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			BinaryHeap<String> pq = BinaryHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}

--- a/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
@@ -758,6 +758,112 @@ public class FibonacciHeapDoubleTests {
 	}
 	
 	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], 1));
+			assertEquals(1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], 100));
+			assertEquals(100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (p < priorities[i]) {
+					assertTrue(pq.promote(elements[i], p));
+				} else {
+					assertTrue(pq.demote(elements[i], p));
+				}
+				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
 	public void testDefaultMinHeap() {
 		int n = 31;
 		String[] elements = createStrings(n);
@@ -1406,6 +1512,112 @@ public class FibonacciHeapDoubleTests {
 				if (!maxElement.equals(elements[j])) {
 					assertEquals(elements[j], pq.pollElement());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], -1));
+			assertEquals(-1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], -100));
+			assertEquals(-100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (-p > priorities[i]) {
+					assertTrue(pq.promote(elements[i], -p));
+				} else {
+					assertTrue(pq.demote(elements[i], -p));
+				}
+				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}

--- a/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
@@ -759,6 +759,112 @@ public class FibonacciHeapTests {
 	}
 	
 	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], 1));
+			assertEquals(1, pq.peekPriority(elements[i]));
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], 100));
+			assertEquals(100, pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (p < priorities[i]) {
+					assertTrue(pq.promote(elements[i], p));
+				} else {
+					assertTrue(pq.demote(elements[i], p));
+				}
+				assertEquals(p, pq.peekPriority(elements[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
 	public void testDefaultMinHeap() {
 		int n = 31;
 		String[] elements = createStrings(n);
@@ -1407,6 +1513,112 @@ public class FibonacciHeapTests {
 				if (!maxElement.equals(elements[j])) {
 					assertEquals(elements[j], pq.pollElement());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], -1));
+			assertEquals(-1, pq.peekPriority(elements[i]));
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], -100));
+			assertEquals(-100, pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				FibonacciHeap<String> pq = FibonacciHeap.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (-p > priorities[i]) {
+					assertTrue(pq.promote(elements[i], -p));
+				} else {
+					assertTrue(pq.demote(elements[i], -p));
+				}
+				assertEquals(-p, pq.peekPriority(elements[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			FibonacciHeap<String> pq = FibonacciHeap.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
 			}
 			assertTrue(pq.isEmpty());
 		}

--- a/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/IntBinaryHeapDoubleTests.java
@@ -339,6 +339,112 @@ public class IntBinaryHeapDoubleTests {
 		}
 	}
 	
+	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = 2*p[i] + 2;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.promote(e[i], 1));
+			assertEquals(1, pq.peekPriority(e[i]), 0.0);
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.demote(e[i], 100));
+			assertEquals(100, pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				if (pNew < p[i]) {
+					assertTrue(pq.promote(e[i], pNew));
+				} else {
+					assertTrue(pq.demote(e[i], pNew));
+				}
+				assertEquals(pNew, pq.peekPriority(e[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] < pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] > pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertFalse(pq.demote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMinHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[n-1], pNew));
+			assertFalse(pq.contains(e[n-1]));
+			assertFalse(pq.demote(e[n-1], pNew));
+			assertFalse(pq.contains(e[n-1]));
+			for (int j = 0; j < n-1; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
 	// MAX HEAP TESTS
 	
 	@Test
@@ -576,6 +682,112 @@ public class IntBinaryHeapDoubleTests {
 				if (p[j] < -pNew) {
 					assertEquals(e[j], pq.poll());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		double[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = -(2*p[i] + 2);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.promote(e[i], -1));
+			assertEquals(-1, pq.peekPriority(e[i]), 0.0);
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.demote(e[i], -100));
+			assertEquals(-100, pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = (2*(n-1) + 2);
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				if (-pNew > p[i]) {
+					assertTrue(pq.promote(e[i], -pNew));
+				} else {
+					assertTrue(pq.demote(e[i], -pNew));
+				}
+				assertEquals(-pNew, pq.peekPriority(e[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] > -pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] < -pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			assertFalse(pq.demote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeapDouble pq = IntBinaryHeapDouble.createMaxHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[n-1], -pNew));
+			assertFalse(pq.contains(e[n-1]));
+			assertFalse(pq.demote(e[n-1], -pNew));
+			assertFalse(pq.contains(e[n-1]));
+			for (int j = 0; j < n-1; j++) {
+				assertEquals(e[j], pq.poll());
 			}
 			assertTrue(pq.isEmpty());
 		}

--- a/src/test/java/org/cicirello/ds/IntBinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/IntBinaryHeapTests.java
@@ -339,6 +339,112 @@ public class IntBinaryHeapTests {
 		}
 	}
 	
+	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		int[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = 2*p[i] + 2;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.promote(e[i], 1));
+			assertEquals(1, pq.peekPriority(e[i]));
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.demote(e[i], 100));
+			assertEquals(100, pq.peekPriority(e[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeap pq = IntBinaryHeap.createMinHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				if (pNew < p[i]) {
+					assertTrue(pq.promote(e[i], pNew));
+				} else {
+					assertTrue(pq.demote(e[i], pNew));
+				}
+				assertEquals(pNew, pq.peekPriority(e[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] < pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] > pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMinHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]));
+			assertFalse(pq.demote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeap pq = IntBinaryHeap.createMinHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[n-1], pNew));
+			assertFalse(pq.contains(e[n-1]));
+			assertFalse(pq.demote(e[n-1], pNew));
+			assertFalse(pq.contains(e[n-1]));
+			for (int j = 0; j < n-1; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
 	// MAX HEAP TESTS
 	
 	@Test
@@ -576,6 +682,112 @@ public class IntBinaryHeapTests {
 				if (p[j] < -pNew) {
 					assertEquals(e[j], pq.poll());
 				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		int[] e = createElements(n);
+		int[] p = orderedArray(n);
+		for (int i = 0; i < n; i++) {
+			p[i] = -(2*p[i] + 2);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.promote(e[i], -1));
+			assertEquals(-1, pq.peekPriority(e[i]));
+			assertEquals(e[i], pq.poll());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertTrue(pq.demote(e[i], -100));
+			assertEquals(-100, pq.peekPriority(e[i]));
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(e[j], pq.poll());
+				}
+			}
+			assertEquals(e[i], pq.poll());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = (2*(n-1) + 2);
+		for (int pNew = 3; pNew <= maxP; pNew += 2) {
+			for (int i = 0; i < n; i++) {
+				IntBinaryHeap pq = IntBinaryHeap.createMaxHeap(n);
+				for (int j = 0; j < n; j++) {
+					pq.offer(e[j], p[j]);
+				}
+				if (-pNew > p[i]) {
+					assertTrue(pq.promote(e[i], -pNew));
+				} else {
+					assertTrue(pq.demote(e[i], -pNew));
+				}
+				assertEquals(-pNew, pq.peekPriority(e[i]));
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (p[j] > -pNew) {
+							assertEquals(e[j], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(e[i], pq.poll(), "p,i,j="+pNew+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && p[j] < -pNew) {
+						assertEquals(e[j], pq.poll());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			IntBinaryHeap pq = IntBinaryHeap.createMaxHeap(n);
+			for (int j = 0; j < n; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]));
+			assertFalse(pq.demote(e[i], p[i]));
+			assertEquals(p[i], pq.peekPriority(e[i]));
+			for (int j = 0; j < n; j++) {
+				assertEquals(e[j], pq.poll());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int pNew = 1; pNew <= maxP; pNew += 2) {
+			IntBinaryHeap pq = IntBinaryHeap.createMaxHeap(n);
+			for (int j = 0; j < n-1; j++) {
+				pq.offer(e[j], p[j]);
+			}
+			assertFalse(pq.promote(e[n-1], -pNew));
+			assertFalse(pq.contains(e[n-1]));
+			assertFalse(pq.demote(e[n-1], -pNew));
+			assertFalse(pq.contains(e[n-1]));
+			for (int j = 0; j < n-1; j++) {
+				assertEquals(e[j], pq.poll());
 			}
 			assertTrue(pq.isEmpty());
 		}


### PR DESCRIPTION
## Summary
Added promote and demote methods to the PriorityQueue, PriorityQueueDouble, IntPriorityQueue, IntPriorityQueueDouble interfaces for changing priorities strictly in one direction, and implemented in the various heap classes.

## Closing Issues
Closes #53 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
