### PR TITLE
Improved BinaryHeap.retainAll and BinaryHeapDouble.retainAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-05-26
+## [Unreleased] - 2022-06-05
 
 ### Added
 
 ### Changed
+* Improved implementation of BinaryHeap.retainAll(Collection) to an O(m + n) runtime.
+* Improved implementation of BinaryHeapDouble.retainAll(Collection) to an O(m + n) runtime.
 
 ### Deprecated
 

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -73,9 +73,9 @@ import org.cicirello.util.Copyable;
  *     {@link #trimToSize}</li>
  * <li><b>O(m):</b> {@link #containsAll(Collection)}, {@link #createMaxHeap(Collection)}, 
  *     {@link #createMinHeap(Collection)}</li>
+ * <li><b>O(n + m):</b> {@link #retainAll(Collection)}</li>
  * <li><b>O(m lg n):</b> {@link #removeAll(Collection)}</li>
  * <li><b>O(m lg (n+m)):</b> {@link #addAll(Collection)}</li>
- * <li><b>O(n lg n):</b> {@link #retainAll(Collection)}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the BinaryHeapDouble.
@@ -492,24 +492,44 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 		return true;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling remove repeatedly, unless you are
+	 * removing a relatively small number of elements, in which case you
+	 * should instead call {@link #remove(Object)} for each element you
+	 * want to remove.</p>
+	 */
 	@Override
 	public final boolean retainAll(Collection<?> c) {
-		HashSet<E> deleteThese = new HashSet<E>();
-		for (int i = 0; i < size; i++) {
-			deleteThese.add(buffer[i].element);
-		}
+		HashSet<Object> keepThese = new HashSet<Object>();
 		for (Object o : c) {
 			if (o instanceof PriorityQueueNode.Double) {
 				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
-				deleteThese.remove(pair.element);
+				keepThese.add(pair.element);
 			} else {
-				deleteThese.remove(o);
+				keepThese.add(o);
 			}
 		}
 		boolean changed = false;
-		for (E e : deleteThese) {
-			remove(e); 
-			changed = true;
+		for (int i = size-1; i >= 0; i--) {
+			if (!keepThese.contains(buffer[i].element)) {
+				changed = true;
+				index.remove(buffer[i].element);
+				size--;
+				if (i == size) {
+					buffer[i] = null;
+				} else {
+					buffer[i] = buffer[size];
+					index.put(buffer[i].element, i);
+					buffer[size] = null;
+				}
+			}
+		}
+		if (changed) {
+			buildHeap();
 		}
 		return changed;
 	}


### PR DESCRIPTION
## Summary
Includes following:
* Improved implementation of BinaryHeap.retainAll(Collection) to an O(m + n) runtime.
* Improved implementation of BinaryHeapDouble.retainAll(Collection) to an O(m + n) runtime.

## Closing Issues
Closes #61 
Closes #62 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
