### PR TITLE
Fixed BinaryHeap.addAll(Collection) and improved clear()

### DIFF
--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -290,8 +290,8 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 			if (index.containsKey(e.element)) {
 				throw new IllegalArgumentException("heap already contains one or more of these elements");
 			}
-			buffer[size] = e;
-			index.put(e.element, size);
+			buffer[size] = e.copy();
+			index.put(buffer[size].element, size);
 			size++;
 		}
 		buildHeap();

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -318,7 +317,9 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 	
 	@Override
 	public final void clear() {
-		Arrays.fill(buffer, null);
+		for (int i = 0; i < size; i++) {
+			buffer[i] = null;
+		}
 		size = 0;
 		index.clear();
 	}

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -318,7 +317,9 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 	
 	@Override
 	public final void clear() {
-		Arrays.fill(buffer, null);
+		for (int i = 0; i < size; i++) {
+			buffer[i] = null;
+		}
 		size = 0;
 		index.clear();
 	}

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -290,8 +290,8 @@ public final class BinaryHeapDouble<E> implements PriorityQueueDouble<E>, Copyab
 			if (index.containsKey(e.element)) {
 				throw new IllegalArgumentException("heap already contains one or more of these elements");
 			}
-			buffer[size] = e;
-			index.put(e.element, size);
+			buffer[size] = e.copy();
+			index.put(buffer[size].element, size);
 			size++;
 		}
 		buildHeap();

--- a/src/main/java/org/cicirello/ds/IntBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeap.java
@@ -135,7 +135,7 @@ public class IntBinaryHeap implements IntPriorityQueue, Copyable<IntBinaryHeap> 
 	@Override
 	public final void clear() {
 		if (size > 0) {
-			Arrays.fill(in, 0, size, false);
+			Arrays.fill(in, false);
 			size = 0;
 		}
 	}

--- a/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/IntBinaryHeapDouble.java
@@ -135,7 +135,7 @@ public class IntBinaryHeapDouble implements IntPriorityQueueDouble, Copyable<Int
 	@Override
 	public final void clear() {
 		if (size > 0) {
-			Arrays.fill(in, 0, size, false);
+			Arrays.fill(in, false);
 			size = 0;
 		}
 	}

--- a/src/main/java/org/cicirello/ds/IntFibonacciHeap.java
+++ b/src/main/java/org/cicirello/ds/IntFibonacciHeap.java
@@ -167,9 +167,11 @@ public class IntFibonacciHeap implements IntPriorityQueue, Copyable<IntFibonacci
 	
 	@Override
 	public final void clear() {
-		size = 0;
-		min = null;
-		Arrays.fill(index, null);
+		if (size > 0) {
+			size = 0;
+			min = null;
+			Arrays.fill(index, null);
+		}
 	}
 	
 	/**

--- a/src/main/java/org/cicirello/ds/IntFibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/IntFibonacciHeapDouble.java
@@ -167,9 +167,11 @@ public class IntFibonacciHeapDouble implements IntPriorityQueueDouble, Copyable<
 	
 	@Override
 	public final void clear() {
-		size = 0;
-		min = null;
-		Arrays.fill(index, null);
+		if (size > 0) {
+			size = 0;
+			min = null;
+			Arrays.fill(index, null);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
## Summary
Fixed issues in addAll method of binary heap classes with potential to break encapsulation (important to store copies of added element, priority pairs and not the exact pairs passed). Also improved clear method of the various heap implementations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
