### PR TITLE
Added mergeable priority queues, and a merge method to binary heap classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-06-06
+## [Unreleased] - 2022-06-07
 
 ### Added
+* MergeablePriorityQueue interface for priority queues with merge support.
+* MergeablePriorityQueueDouble interface for priority queues with merge support.
+* BinaryHeap.merge(BinaryHeap) for merging binary heaps with int priorities.
+* BinaryHeapDouble.merge(BinaryHeapDouble) for merging binary heaps with double priorities.
 
 ### Changed
 * Improved implementation of BinaryHeap.retainAll(Collection) to an O(m + n) runtime.

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -72,7 +72,7 @@ import org.cicirello.util.Copyable;
  * <li><b>O(n):</b> {@link #clear}, {@link #copy()}, {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, 
  *     {@link #toArray()}, {@link #toArray(Object[])}, 
  *     {@link #trimToSize}</li>
- * <li><b>O(n + m):</b> {@link #addAll(Collection)}, {@link #removeAll(Collection)}, {@link #retainAll(Collection)}</li>
+ * <li><b>O(n + m):</b> {@link #addAll(Collection)}, {@link #merge(BinaryHeap)}, {@link #removeAll(Collection)}, {@link #retainAll(Collection)}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the BinaryHeap.
@@ -80,7 +80,7 @@ import org.cicirello.util.Copyable;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHeap<E>> {
+public final class BinaryHeap<E> implements MergeablePriorityQueue<E, BinaryHeap<E>>, Copyable<BinaryHeap<E>> {
 	
 	private PriorityQueueNode.Integer<E>[] buffer;
 	private int size;
@@ -285,6 +285,7 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 		if (size + c.size() > buffer.length) {
 			internalAdjustCapacity((size + c.size()) << 1);
 		}
+		boolean changed = false;
 		for (PriorityQueueNode.Integer<E> e : c) {
 			if (index.containsKey(e.element)) {
 				throw new IllegalArgumentException("heap already contains one or more of these elements");
@@ -292,9 +293,12 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 			buffer[size] = e.copy();
 			index.put(buffer[size].element, size);
 			size++;
+			changed = true;
 		}
-		buildHeap();
-		return true;
+		if (changed) {
+			buildHeap();
+		}
+		return changed;
 	}
 	
 	@Override
@@ -412,6 +416,34 @@ public final class BinaryHeap<E> implements PriorityQueue<E>, Copyable<BinaryHea
 	@Override
 	public final Iterator<PriorityQueueNode.Integer<E>> iterator() {
 		return new BinaryHeapIterator();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if this and other have different priority-order (e.g., one is a 
+	 * minheap while the other is a maxheap)
+	 */
+	@Override
+	public boolean merge(BinaryHeap<E> other) {
+		if (compare.belongsAbove(0,1) != other.compare.belongsAbove(0,1)) {
+			throw new IllegalArgumentException("this and other follow different priority-order");
+		}
+		if (size + other.size() > buffer.length) {
+			internalAdjustCapacity((size + other.size()) << 1);
+		}
+		boolean changed = false;
+		for (int i = 0; i < other.size; i++) {
+			buffer[size] = other.buffer[i];
+			index.put(buffer[size].element, size);
+			size++;
+			changed = true;
+		}
+		if (changed) {
+			other.clear();
+			buildHeap();
+		}
+		return changed;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/MergeablePriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/MergeablePriorityQueue.java
@@ -1,0 +1,54 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+/**
+ * <p>A MergeablePriorityQueue is a PriorityQueue that includes a merge
+ * method. All PriorityQueue 
+ * implementations enforce distinct elements, and use the
+ * {@link Object#hashCode} and {@link Object#equals} methods to
+ * to enforce distinctness, so be sure that the class of the elements
+ * properly implements these methods, or else behavior is not guaranteed.</p>
+ *
+ * @param <E> The type of object contained in the PriorityQueue.
+ * @param <T> The type of MergeablePriorityQueue supported by the merge
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public interface MergeablePriorityQueue<E, T extends MergeablePriorityQueue<E, T>> extends PriorityQueue<E> {
+	
+	/**
+	 * <p>Merges another priority queue into this one, adding all of its (element, priority) pairs.
+	 * This is a destructive operation with no guarantees to the state of the other priority queue
+	 * upon completion. Additionally, implementations of this method may assume that <code>other</code> and <code>this</code>
+	 * do not share any elements, and the priority queue may become unstable if they do. The priority order
+	 * of both priority queues must be the same (e.g., both minheaps or both maxheaps).</p>
+	 *
+	 * @param other The priority queue that you want to merge into <code>this</code>. Implementations
+	 * need not make any guarantees as to the state of <code>other</code> upon completion.
+	 *
+	 * @return true if and only if this priority queue changed as a result of the merge
+	 */
+	boolean merge(T other);
+}

--- a/src/main/java/org/cicirello/ds/MergeablePriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/MergeablePriorityQueueDouble.java
@@ -1,0 +1,54 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+/**
+ * <p>A MergeablePriorityQueueDouble is a PriorityQueueDouble that includes a merge
+ * method. All PriorityQueueDouble 
+ * implementations enforce distinct elements, and use the
+ * {@link Object#hashCode} and {@link Object#equals} methods to
+ * to enforce distinctness, so be sure that the class of the elements
+ * properly implements these methods, or else behavior is not guaranteed.</p>
+ *
+ * @param <E> The type of object contained in the PriorityQueueDouble.
+ * @param <T> The type of MergeablePriorityQueueDouble supported by the merge
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public interface MergeablePriorityQueueDouble<E, T extends MergeablePriorityQueueDouble<E, T>> extends PriorityQueueDouble<E> {
+	
+	/**
+	 * <p>Merges another priority queue into this one, adding all of its (element, priority) pairs.
+	 * This is a destructive operation with no guarantees to the state of the other priority queue
+	 * upon completion. Additionally, implementations of this method may assume that <code>other</code> and <code>this</code>
+	 * do not share any elements, and the priority queue may become unstable if they do. The priority order
+	 * of both priority queues must be the same (e.g., both minheaps or both maxheaps).</p>
+	 *
+	 * @param other The priority queue that you want to merge into <code>this</code>. Implementations
+	 * need not make any guarantees as to the state of <code>other</code> upon completion.
+	 *
+	 * @return true if and only if this priority queue changed as a result of the merge
+	 */
+	boolean merge(T other);
+}

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -38,6 +38,50 @@ public class BinaryHeapDoubleTests {
 	// TESTS THAT ARE NEITHER STRICTLY MIN HEAP TESTS NOW MAX HEAP TESTS
 	
 	@Test
+	public void testMerge() {
+		int n = 24;
+		String[] elements1 = new String[n];
+		double[] priorities1 = new double[n];
+		String[] elements2 = new String[n];
+		double[] priorities2 = new double[n];
+		ArrayList<PriorityQueueNode.Double<String>> list1 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list2 = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < 2*n; i+=2) {
+			elements1[i/2] = "A" + i;
+			elements2[i/2] = "A" + (i+1);
+			priorities1[i/2] = i;
+			priorities2[i/2] = i+1;
+			list1.add(new PriorityQueueNode.Double<String>(elements1[i/2], priorities1[i/2]));
+			list2.add(new PriorityQueueNode.Double<String>(elements2[i/2], priorities2[i/2]));
+		}
+		final BinaryHeapDouble<String> pq1 = BinaryHeapDouble.createMinHeap(list1);
+		final BinaryHeapDouble<String> pq2 = BinaryHeapDouble.createMinHeap(list2);
+		assertFalse(pq1.merge(BinaryHeapDouble.createMinHeap()));
+		assertTrue(pq1.merge(pq2));
+		assertEquals(4*n, pq1.capacity());
+		assertTrue(pq2.isEmpty());
+		assertEquals(0, pq2.size());
+		assertEquals(2*n, pq1.size());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq1.contains(elements1[i]));
+			assertTrue(pq1.contains(elements2[i]));
+			assertEquals(priorities1[i], pq1.peekPriority(elements1[i]));
+			assertEquals(priorities2[i], pq1.peekPriority(elements2[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(list1.get(i), pq1.poll());
+			assertEquals(list2.get(i), pq1.poll());
+		}
+		assertTrue(pq1.isEmpty());
+		assertEquals(0, pq1.size());
+		
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq1.merge(BinaryHeapDouble.createMaxHeap())
+		);
+	}
+	
+	@Test
 	public void testAddAll() {
 		String[] elements = {"A", "B", "C", "D"};
 		double[] priorities = { 8, 6, 4, 2 };
@@ -74,6 +118,17 @@ public class BinaryHeapDoubleTests {
 			assertEquals(priorities2[i], pq.peekPriority(elements2[i]), 0.0);
 		}
 		
+		assertFalse(pq.addAll(new ArrayList<PriorityQueueNode.Double<String>>()));
+		assertEquals(elements.length + elements2.length, pq.size());
+		assertEquals((elements.length + elements2.length)*2, pq.capacity());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		for (int i = 0; i < elements2.length; i++) {
+			assertTrue(pq.contains(elements2[i]));
+			assertEquals(priorities2[i], pq.peekPriority(elements2[i]), 0.0);
+		}
 		
 		IllegalArgumentException thrown = assertThrows( 
 			IllegalArgumentException.class,

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -38,6 +38,50 @@ public class BinaryHeapTests {
 	// TESTS THAT ARE NEITHER STRICTLY MIN HEAP TESTS NOW MAX HEAP TESTS
 	
 	@Test
+	public void testMerge() {
+		int n = 24;
+		String[] elements1 = new String[n];
+		int[] priorities1 = new int[n];
+		String[] elements2 = new String[n];
+		int[] priorities2 = new int[n];
+		ArrayList<PriorityQueueNode.Integer<String>> list1 = new ArrayList<PriorityQueueNode.Integer<String>>();
+		ArrayList<PriorityQueueNode.Integer<String>> list2 = new ArrayList<PriorityQueueNode.Integer<String>>();
+		for (int i = 0; i < 2*n; i+=2) {
+			elements1[i/2] = "A" + i;
+			elements2[i/2] = "A" + (i+1);
+			priorities1[i/2] = i;
+			priorities2[i/2] = i+1;
+			list1.add(new PriorityQueueNode.Integer<String>(elements1[i/2], priorities1[i/2]));
+			list2.add(new PriorityQueueNode.Integer<String>(elements2[i/2], priorities2[i/2]));
+		}
+		final BinaryHeap<String> pq1 = BinaryHeap.createMinHeap(list1);
+		final BinaryHeap<String> pq2 = BinaryHeap.createMinHeap(list2);
+		assertFalse(pq1.merge(BinaryHeap.createMinHeap()));
+		assertTrue(pq1.merge(pq2));
+		assertEquals(4*n, pq1.capacity());
+		assertTrue(pq2.isEmpty());
+		assertEquals(0, pq2.size());
+		assertEquals(2*n, pq1.size());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq1.contains(elements1[i]));
+			assertTrue(pq1.contains(elements2[i]));
+			assertEquals(priorities1[i], pq1.peekPriority(elements1[i]));
+			assertEquals(priorities2[i], pq1.peekPriority(elements2[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(list1.get(i), pq1.poll());
+			assertEquals(list2.get(i), pq1.poll());
+		}
+		assertTrue(pq1.isEmpty());
+		assertEquals(0, pq1.size());
+		
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq1.merge(BinaryHeap.createMaxHeap())
+		);
+	}
+	
+	@Test
 	public void testAddAll() {
 		String[] elements = {"A", "B", "C", "D"};
 		int[] priorities = { 8, 6, 4, 2 };
@@ -67,11 +111,23 @@ public class BinaryHeapTests {
 		assertEquals((elements.length + elements2.length)*2, pq.capacity());
 		for (int i = 0; i < elements.length; i++) {
 			assertTrue(pq.contains(elements[i]));
-			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
 		}
 		for (int i = 0; i < elements2.length; i++) {
 			assertTrue(pq.contains(elements2[i]));
-			assertEquals(priorities2[i], pq.peekPriority(elements2[i]), 0.0);
+			assertEquals(priorities2[i], pq.peekPriority(elements2[i]));
+		}
+		
+		assertFalse(pq.addAll(new ArrayList<PriorityQueueNode.Integer<String>>()));
+		assertEquals(elements.length + elements2.length, pq.size());
+		assertEquals((elements.length + elements2.length)*2, pq.capacity());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]));
+		}
+		for (int i = 0; i < elements2.length; i++) {
+			assertTrue(pq.contains(elements2[i]));
+			assertEquals(priorities2[i], pq.peekPriority(elements2[i]));
 		}
 		
 		IllegalArgumentException thrown = assertThrows( 


### PR DESCRIPTION
## Summary
Adds the following:
* MergeablePriorityQueue interface for priority queues with merge support.
* MergeablePriorityQueueDouble interface for priority queues with merge support.
* BinaryHeap.merge(BinaryHeap) for merging binary heaps with int priorities.
* BinaryHeapDouble.merge(BinaryHeapDouble) for merging binary heaps with double priorities.

## Closing Issues
Closes #78 
Closes #79 
Closes #82 
Closes #83 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
