### PR TITLE
Configure JDK version for jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
## Summary
JitPack assumes JDK 8. Added configuration file to configure for JDK 17.
