### PR TITLE
Changed version in pom.xml to a SNAPSHOT

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -63,15 +63,3 @@ jobs:
         gh release upload ${TAG} target/${{ env.artifact_name }}-${{ steps.get_version.outputs.VERSION }}-javadoc.jar 
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update version in pom with a Pull Request
-      uses: peter-evans/create-pull-request@v4.0.4
-      with:
-        title: "Automated update: version in pom.xml"
-        commit-message: "Automated update: version in pom.xml"
-        add-paths: pom.xml
-        branch: create-pull-request/version-update
-        delete-branch: true
-        author: Vincent A. Cicirello <cicirello@users.noreply.github.com>
-        committer: Vincent A. Cicirello <cicirello@users.noreply.github.com>
-        body: "Automated update: New version extracted from release tag and injected into pom.xml."

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
 	<groupId>org.cicirello</groupId>
 	<artifactId>core</artifactId>
-	<version>2.0.0</version>
+	<version>2-SNAPSHOT</version>
 	<packaging>jar</packaging>
   
 	<name>core</name>


### PR DESCRIPTION
## Summary
We currently inject the real version during our deployment to Maven Central. The version field in pom.xml tends to be out of synch otherwise, so if someone builds locally the artifacts are almost certainly named wrong. Changed version defined in pom.xml to 2-SNAPSHOT. Will now increment that on major releases only.
