### PR TITLE
Add workflow to trigger build on JitPack on pushes to main

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -1,0 +1,22 @@
+# Triggers a snapshot build on JitPack for the custom domain.
+# Already have a webhook setup, but that won't trigger the build
+# for the custom domain.
+
+name: jitpack-build
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  jitpack:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Request main-SNAPSHOT from JitPack
+      run: |
+        # timeout in 1 second to avoid waiting for build
+        STATUS=$(curl -m 1 https://jitpack.io/org/cicirello/core/main-SNAPSHOT/)
+        exit 0


### PR DESCRIPTION
## Summary
Added workflow to trigger build on JitPack on pushes to main. There is already a webhook configured to do this, but the webhook only works to cause the build if artifacts requested using repository as group. It doesn't work for custom domains configured on jitpack. This workflow should fix that.
