### PR TITLE
Documentation edits regarding distinctness in PQ interfaces and classes

### DIFF
--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -446,6 +446,16 @@ public final class BinaryHeap<E> implements MergeablePriorityQueue<E, BinaryHeap
 		return changed;
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the BinaryHeap with a specified priority,
+	 * provided the element is not already in the BinaryHeap.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * BinaryHeap already contained the element.
+	 */
 	@Override
 	public final boolean offer(E element, int priority) {
 		if (contains(element)) {
@@ -454,6 +464,15 @@ public final class BinaryHeap<E> implements MergeablePriorityQueue<E, BinaryHeap
 		return internalOffer(new PriorityQueueNode.Integer<E>(element, priority));
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the BinaryHeap,
+	 * provided the element is not already in the BinaryHeap.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * BinaryHeap already contained the element.
+	 */
 	@Override
 	public final boolean offer(PriorityQueueNode.Integer<E> pair) {
 		if (contains(pair.element)) {

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -447,6 +447,16 @@ public final class BinaryHeapDouble<E> implements MergeablePriorityQueueDouble<E
 		return changed;
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the BinaryHeapDouble with a specified priority,
+	 * provided the element is not already in the BinaryHeapDouble.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * BinaryHeapDouble already contained the element.
+	 */
 	@Override
 	public final boolean offer(E element, double priority) {
 		if (contains(element)) {
@@ -455,6 +465,15 @@ public final class BinaryHeapDouble<E> implements MergeablePriorityQueueDouble<E
 		return internalOffer(new PriorityQueueNode.Double<E>(element, priority));
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the BinaryHeapDouble,
+	 * provided the element is not already in the BinaryHeapDouble.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * BinaryHeapDouble already contained the element.
+	 */
 	@Override
 	public final boolean offer(PriorityQueueNode.Double<E> pair) {
 		if (contains(pair.element)) {

--- a/src/main/java/org/cicirello/ds/FibonacciHeap.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeap.java
@@ -360,6 +360,16 @@ public final class FibonacciHeap<E> implements MergeablePriorityQueue<E, Fibonac
 		return false;
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the FibonacciHeap with a specified priority,
+	 * provided the element is not already in the FibonacciHeap.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * FibonacciHeap already contained the element.
+	 */
 	@Override
 	public final boolean offer(E element, int priority) {
 		if (index.containsKey(element)) {
@@ -368,6 +378,15 @@ public final class FibonacciHeap<E> implements MergeablePriorityQueue<E, Fibonac
 		return internalOffer(new PriorityQueueNode.Integer<E>(element, priority));
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the FibonacciHeap,
+	 * provided the element is not already in the FibonacciHeap.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * FibonacciHeap already contained the element.
+	 */
 	@Override
 	public final boolean offer(PriorityQueueNode.Integer<E> pair) {
 		if (index.containsKey(pair.element)) {

--- a/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
@@ -360,6 +360,16 @@ public final class FibonacciHeapDouble<E> implements MergeablePriorityQueueDoubl
 		return false;
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the FibonacciHeapDouble with a specified priority,
+	 * provided the element is not already in the FibonacciHeapDouble.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * FibonacciHeapDouble already contained the element.
+	 */
 	@Override
 	public final boolean offer(E element, double priority) {
 		if (index.containsKey(element)) {
@@ -368,6 +378,15 @@ public final class FibonacciHeapDouble<E> implements MergeablePriorityQueueDoubl
 		return internalOffer(new PriorityQueueNode.Double<E>(element, priority));
 	}
 	
+	/**
+	 * Adds an (element, priority) pair to the FibonacciHeapDouble,
+	 * provided the element is not already in the FibonacciHeapDouble.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added, and false if the
+	 * FibonacciHeapDouble already contained the element.
+	 */
 	@Override
 	public final boolean offer(PriorityQueueNode.Double<E> pair) {
 		if (index.containsKey(pair.element)) {

--- a/src/main/java/org/cicirello/ds/MergeablePriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/MergeablePriorityQueue.java
@@ -24,11 +24,7 @@ package org.cicirello.ds;
 
 /**
  * <p>A MergeablePriorityQueue is a PriorityQueue that includes a merge
- * method. All PriorityQueue 
- * implementations enforce distinct elements, and use the
- * {@link Object#hashCode} and {@link Object#equals} methods to
- * to enforce distinctness, so be sure that the class of the elements
- * properly implements these methods, or else behavior is not guaranteed.</p>
+ * method.</p>
  *
  * @param <E> The type of object contained in the PriorityQueue.
  * @param <T> The type of MergeablePriorityQueue supported by the merge
@@ -41,7 +37,7 @@ public interface MergeablePriorityQueue<E, T extends MergeablePriorityQueue<E, T
 	/**
 	 * <p>Merges another priority queue into this one, adding all of its (element, priority) pairs.
 	 * This is a destructive operation with no guarantees to the state of the other priority queue
-	 * upon completion. Additionally, implementations of this method may assume that <code>other</code> and <code>this</code>
+	 * upon completion. Additionally, <b>some</b> implementations of this method may assume that <code>other</code> and <code>this</code>
 	 * do not share any elements, and the priority queue may become unstable if they do. The priority order
 	 * of both priority queues must be the same (e.g., both minheaps or both maxheaps).</p>
 	 *

--- a/src/main/java/org/cicirello/ds/MergeablePriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/MergeablePriorityQueueDouble.java
@@ -24,11 +24,7 @@ package org.cicirello.ds;
 
 /**
  * <p>A MergeablePriorityQueueDouble is a PriorityQueueDouble that includes a merge
- * method. All PriorityQueueDouble 
- * implementations enforce distinct elements, and use the
- * {@link Object#hashCode} and {@link Object#equals} methods to
- * to enforce distinctness, so be sure that the class of the elements
- * properly implements these methods, or else behavior is not guaranteed.</p>
+ * method.</p> 
  *
  * @param <E> The type of object contained in the PriorityQueueDouble.
  * @param <T> The type of MergeablePriorityQueueDouble supported by the merge
@@ -41,7 +37,7 @@ public interface MergeablePriorityQueueDouble<E, T extends MergeablePriorityQueu
 	/**
 	 * <p>Merges another priority queue into this one, adding all of its (element, priority) pairs.
 	 * This is a destructive operation with no guarantees to the state of the other priority queue
-	 * upon completion. Additionally, implementations of this method may assume that <code>other</code> and <code>this</code>
+	 * upon completion. Additionally, <b>some</b> implementations of this method may assume that <code>other</code> and <code>this</code>
 	 * do not share any elements, and the priority queue may become unstable if they do. The priority order
 	 * of both priority queues must be the same (e.g., both minheaps or both maxheaps).</p>
 	 *

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -29,11 +29,7 @@ import java.util.Queue;
 
 /**
  * <p>Interface common to the classes that provide implementations of
- * a priority queue with int valued priorities. All PriorityQueue 
- * implementations enforce distinct elements, and use the
- * {@link Object#hashCode} and {@link Object#equals} methods to
- * to enforce distinctness, so be sure that the class of the elements
- * properly implements these methods, or else behavior is not guaranteed.</p>
+ * a priority queue with int valued priorities.</p>
  *
  * @param <E> The type of object contained in the PriorityQueue.
  *
@@ -43,18 +39,19 @@ import java.util.Queue;
 public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
-	 * provided the element is not already in the PriorityQueue.
-	 * This method differs from {@link #offer(Object, int)}
-	 * in that it throws an exception if the PriorityQueue contains the element,
-	 * while the offer method instead returns false.
+	 * <p>Adds an (element, priority) pair to the PriorityQueue with a specified priority.</p>
+	 *
+	 * <p>This method differs from {@link #offer(Object, int)}
+	 * in that it throws an exception if the add fails, while the offer method instead returns false,
+	 * which will occur for the class implementations that require distinct elements. For classes
+	 * implementing this interface that do not require distinctness, this method should never fail.</p>
 	 *
 	 * @param element The element.
 	 * @param priority The priority of the element.
 	 *
 	 * @return true if the (element, priority) pair was added.
 	 *
-	 * @throws IllegalArgumentException if the priority queue already contains the element.
+	 * @throws IllegalArgumentException if the add fails for those implementations that require distinctness.
 	 */
 	default boolean add(E element, int priority) {
 		if (!offer(element, priority)) {
@@ -64,17 +61,18 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	}
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue,
-	 * provided the element is not already in the PriorityQueue.
-	 * This method differs from {@link #offer(PriorityQueueNode.Integer)}
-	 * in that it throws an exception if the PriorityQueue contains the element,
-	 * while the offer method instead returns false.
+	 * <p>Adds an (element, priority) pair to the PriorityQueue.</p>
+	 *
+	 * <p>This method differs from {@link #offer(PriorityQueueNode.Integer)}
+	 * in that it throws an exception if the add fails, while the offer method instead returns false,
+	 * which will occur for the class implementations that require distinct elements. For classes
+	 * implementing this interface that do not require distinctness, this method should never fail.</p>
 	 *
 	 * @param pair The (element, priority) pair to add.
 	 *
 	 * @return true if the (element, priority) pair was added.
 	 *
-	 * @throws IllegalArgumentException if the priority queue already contains the element.
+	 * @throws IllegalArgumentException if the add fails for those implementations that require distinctness.
 	 */
 	@Override
 	default boolean add(PriorityQueueNode.Integer<E> pair) {
@@ -85,17 +83,18 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	}
 	
 	/**
-	 * Adds all (element, priority) pairs from a Collection to the PriorityQueue,
-	 * provided the elements are not already in the PriorityQueue.
-	 * The default implementation calls the {@link #add(PriorityQueueNode.Integer)} 
-	 * for each pair in the Collection. 
+	 * <p>Adds all (element, priority) pairs from a Collection to the PriorityQueue.</p>
+	 *
+	 * <p>The default implementation calls the {@link #add(PriorityQueueNode.Integer)} 
+	 * for each pair in the Collection.</p> 
 	 *
 	 * @param c the Collection of (element, priority) pairs to add.
 	 *
 	 * @return true if the (element, priority) pairs were added.
 	 *
-	 * @throws IllegalArgumentException if the PriorityQueue already contains any
-	 * of the (element, priority) pairs.
+	 * @throws IllegalArgumentException if the PriorityQueue fails to add any
+	 * of the (element, priority) pairs, which will occur only for the implementations that require
+	 * distinctness.
 	 */
 	@Override
 	default boolean addAll(Collection<? extends PriorityQueueNode.Integer<E>> c) {
@@ -213,25 +212,21 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	Iterator<PriorityQueueNode.Integer<E>> iterator();
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueue with a specified priority.
 	 *
 	 * @param element The element.
 	 * @param priority The priority of the element.
 	 *
-	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueue already contained the element.
+	 * @return true if the (element, priority) pair was added, and false otherwise
 	 */
 	boolean offer(E element, int priority);
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueue,
-	 * provided the element is not already in the PriorityQueue.
+	 * Adds an (element, priority) pair to the PriorityQueue.
 	 *
 	 * @param pair The (element, priority) pair to add.
 	 *
-	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueue already contained the element.
+	 * @return true if the (element, priority) pair was added, and false otherwise
 	 */
 	@Override
 	boolean offer(PriorityQueueNode.Integer<E> pair);

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -29,11 +29,7 @@ import java.util.Queue;
 
 /**
  * <p>Interface common to the classes that provide implementations of
- * a priority queue with double valued priorities. All PriorityQueueDouble 
- * implementations enforce distinct elements, and use the
- * {@link Object#hashCode} and {@link Object#equals} methods to
- * to enforce distinctness, so be sure that the class of the elements
- * properly implements these methods, or else behavior is not guaranteed.</p>
+ * a priority queue with double valued priorities.</p>
  *
  * @param <E> The type of object contained in the PriorityQueueDouble.
  *
@@ -43,18 +39,19 @@ import java.util.Queue;
 public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E>> {
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority,
-	 * provided the element is not already in the PriorityQueueDouble.
-	 * This method differs from {@link #offer(Object, double)}
-	 * in that it throws an exception if the PriorityQueueDouble contains the element,
-	 * while the offer method instead returns false.
+	 * <p>Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority.</p>
+	 *
+	 * <p>This method differs from {@link #offer(Object, double)}
+	 * in that it throws an exception if the add fails, while the offer method instead returns false,
+	 * which will occur for the class implementations that require distinct elements. For classes
+	 * implementing this interface that do not require distinctness, this method should never fail.</p>
 	 *
 	 * @param element The element.
 	 * @param priority The priority of the element.
 	 *
 	 * @return true if the (element, priority) pair was added.
 	 *
-	 * @throws IllegalArgumentException if the priority queue already contains the element.
+	 * @throws IllegalArgumentException if the add fails for those implementations that require distinctness.
 	 */
 	default boolean add(E element, double priority) {
 		if (!offer(element, priority)) {
@@ -64,17 +61,18 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueueDouble,
-	 * provided the element is not already in the PriorityQueueDouble.
-	 * This method differs from {@link #offer(PriorityQueueNode.Double)}
-	 * in that it throws an exception if the PriorityQueueDouble contains the element,
-	 * while the offer method instead returns false.
+	 * <p>Adds an (element, priority) pair to the PriorityQueueDouble.</p>
+	 *
+	 * <p>This method differs from {@link #offer(PriorityQueueNode.Double)}
+	 * in that it throws an exception if the add fails, while the offer method instead returns false,
+	 * which will occur for the class implementations that require distinct elements. For classes
+	 * implementing this interface that do not require distinctness, this method should never fail.</p>
 	 *
 	 * @param pair The (element, priority) pair to add.
 	 *
 	 * @return true if the (element, priority) pair was added.
 	 *
-	 * @throws IllegalArgumentException if the priority queue already contains the element.
+	 * @throws IllegalArgumentException if the add fails for those implementations that require distinctness.
 	 */
 	@Override
 	default boolean add(PriorityQueueNode.Double<E> pair) {
@@ -85,17 +83,18 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	}
 	
 	/**
-	 * Adds all (element, priority) pairs from a Collection to the PriorityQueueDouble,
-	 * provided the elements are not already in the PriorityQueueDouble.
-	 * The default implementation calls the {@link #add(PriorityQueueNode.Double)} 
-	 * for each pair in the Collection. 
+	 * <p>Adds all (element, priority) pairs from a Collection to the PriorityQueueDouble.</p>
+	 *
+	 * <p>The default implementation calls the {@link #add(PriorityQueueNode.Double)} 
+	 * for each pair in the Collection.</p> 
 	 *
 	 * @param c the Collection of (element, priority) pairs to add.
 	 *
 	 * @return true if the (element, priority) pairs were added.
 	 *
-	 * @throws IllegalArgumentException if the PriorityQueueDouble already contains any
-	 * of the (element, priority) pairs.
+	 * @throws IllegalArgumentException if the PriorityQueueDouble fails to add any
+	 * of the (element, priority) pairs, which will occur only for the implementations that require
+	 * distinctness.
 	 */
 	@Override
 	default boolean addAll(Collection<? extends PriorityQueueNode.Double<E>> c) {
@@ -213,25 +212,21 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	Iterator<PriorityQueueNode.Double<E>> iterator();
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority,
-	 * provided the element is not already in the PriorityQueueDouble.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble with a specified priority.
 	 *
 	 * @param element The element.
 	 * @param priority The priority of the element.
 	 *
-	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueueDouble already contained the element.
+	 * @return true if the (element, priority) pair was added, and false otherwise.
 	 */
 	boolean offer(E element, double priority);
 	
 	/**
-	 * Adds an (element, priority) pair to the PriorityQueueDouble,
-	 * provided the element is not already in the PriorityQueueDouble.
+	 * Adds an (element, priority) pair to the PriorityQueueDouble.
 	 *
 	 * @param pair The (element, priority) pair to add.
 	 *
-	 * @return true if the (element, priority) pair was added, and false if the
-	 * PriorityQueueDouble already contained the element.
+	 * @return true if the (element, priority) pair was added, and false otherwise.
 	 */
 	@Override
 	boolean offer(PriorityQueueNode.Double<E> pair);


### PR DESCRIPTION
## Summary
Moved documentation of distinct elements from the priority queue interfaces into the docs of the specific class implementations that require it. At the current time, that is all of them. However, there are new PQ classes planned (see #101 and #102) that will allow duplicates.

## Closing Issues
Closes #104 
Closes #105 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
