### PR TITLE
Added pollThenAdd() methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-07-11
+## [Unreleased] - 2022-09-14
 
 ### Added
+* PriorityQueue.pollThenAdd and PriorityQueueDouble.pollThenAdd methods, including default implementation in
+  the interfaces, and overridden implementation in the binary heap classes that exploit binary heap structure.
 
 ### Changed
 

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -528,6 +528,67 @@ public final class BinaryHeap<E> implements MergeablePriorityQueue<E, BinaryHeap
 		}
 	}
 	
+	/**
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue,
+	 * adding a new (element, priority) pair prior to returning.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return the next (element, priority) pair in priority order, or null if empty prior to the call.
+	 *
+	 * @throws IllegalArgumentException if, after the poll part of this operation, the priority queue contains
+	 * the element from the pair to add.
+	 */
+	@Override
+	public final PriorityQueueNode.Integer<E> pollThenAdd(PriorityQueueNode.Integer<E> pair) {
+		PriorityQueueNode.Integer<E> min = size > 0 ? buffer[0] : null;
+		if (min != null) {
+			index.remove(min.element);
+		}
+		if (contains(pair.element)) {
+			throw new IllegalArgumentException("This priority queue doesn't support duplicate elements, and already contains the element.");
+		}
+		buffer[0] = pair.copy();
+		index.put(buffer[0].element, 0);
+		if (size <= 0) {
+			size = 1;
+		} else {
+			percolateDown(0);
+		}
+		return min;
+	}
+	
+	/**
+	 * Removes and returns the next element in priority order from this PriorityQueue,
+	 * adding a new (element, priority) pair to the PriorityQueueDouble with a specified priority.
+	 *
+	 * @param element The new element.
+	 * @param priority The priority of the new element.
+	 *
+	 * @return the next element in priority order, or null if empty.
+	 *
+	 * @throws IllegalArgumentException if, after the poll part of this operation, the priority queue contains
+	 * the element.
+	 */
+	@Override
+	public final E pollThenAdd(E element, int priority) {
+		E min = size > 0 ? buffer[0].element : null;
+		if (min != null) {
+			index.remove(min);
+		}
+		if (contains(element)) {
+			throw new IllegalArgumentException("This priority queue doesn't support duplicate elements, and already contains the element.");
+		}
+		buffer[0] = new PriorityQueueNode.Integer<E>(element, priority);
+		index.put(buffer[0].element, 0);
+		if (size <= 0) {
+			size = 1;
+		} else {
+			percolateDown(0);
+		}
+		return min;
+	}
+	
 	@Override
 	public final boolean promote(E element, int priority) {
 		Integer where = index.get(element);

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -529,6 +529,67 @@ public final class BinaryHeapDouble<E> implements MergeablePriorityQueueDouble<E
 		}
 	}
 	
+	/**
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueueDouble,
+	 * adding a new (element, priority) pair prior to returning.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return the next (element, priority) pair in priority order, or null if empty prior to the call.
+	 *
+	 * @throws IllegalArgumentException if, after the poll part of this operation, the priority queue contains
+	 * the element from the pair to add.
+	 */
+	@Override
+	public final PriorityQueueNode.Double<E> pollThenAdd(PriorityQueueNode.Double<E> pair) {
+		PriorityQueueNode.Double<E> min = size > 0 ? buffer[0] : null;
+		if (min != null) {
+			index.remove(min.element);
+		}
+		if (contains(pair.element)) {
+			throw new IllegalArgumentException("This priority queue doesn't support duplicate elements, and already contains the element.");
+		}
+		buffer[0] = pair.copy();
+		index.put(buffer[0].element, 0);
+		if (size <= 0) {
+			size = 1;
+		} else {
+			percolateDown(0);
+		}
+		return min;
+	}
+	
+	/**
+	 * Removes and returns the next element in priority order from this PriorityQueueDouble,
+	 * adding a new (element, priority) pair to the PriorityQueueDouble with a specified priority.
+	 *
+	 * @param element The new element.
+	 * @param priority The priority of the new element.
+	 *
+	 * @return the next element in priority order, or null if empty.
+	 *
+	 * @throws IllegalArgumentException if, after the poll part of this operation, the priority queue contains
+	 * the element.
+	 */
+	@Override
+	public final E pollThenAdd(E element, double priority) {
+		E min = size > 0 ? buffer[0].element : null;
+		if (min != null) {
+			index.remove(min);
+		}
+		if (contains(element)) {
+			throw new IllegalArgumentException("This priority queue doesn't support duplicate elements, and already contains the element.");
+		}
+		buffer[0] = new PriorityQueueNode.Double<E>(element, priority);
+		index.put(buffer[0].element, 0);
+		if (size <= 0) {
+			size = 1;
+		} else {
+			percolateDown(0);
+		}
+		return min;
+	}
+	
 	@Override
 	public final boolean promote(E element, double priority) {
 		Integer where = index.get(element);

--- a/src/main/java/org/cicirello/ds/PriorityQueue.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueue.java
@@ -282,6 +282,35 @@ public interface PriorityQueue<E> extends Queue<PriorityQueueNode.Integer<E>> {
 	E pollElement();
 	
 	/**
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueue,
+	 * adding a new (element, priority) pair prior to returning.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return the next (element, priority) pair in priority order, or null if empty prior to the call.
+	 */
+	default PriorityQueueNode.Integer<E> pollThenAdd(PriorityQueueNode.Integer<E> pair) {
+		PriorityQueueNode.Integer<E> next = poll();
+		add(pair);
+		return next;
+	}
+	
+	/**
+	 * Removes and returns the next element in priority order from this PriorityQueue,
+	 * adding a new (element, priority) pair to the PriorityQueue with a specified priority.
+	 *
+	 * @param element The new element.
+	 * @param priority The priority of the new element.
+	 *
+	 * @return the next element in priority order, or null if empty.
+	 */
+	default E pollThenAdd(E element, int priority) {
+		E e = pollElement();
+		add(element, priority);
+		return e;
+	}
+	
+	/**
 	 * Promotes an element relative to priority order if the element is
 	 * present in the PriorityQueue. For a min-heap, promotion means
 	 * decreasing the element's priority, while for a max-heap, promotion

--- a/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
+++ b/src/main/java/org/cicirello/ds/PriorityQueueDouble.java
@@ -282,6 +282,35 @@ public interface PriorityQueueDouble<E> extends Queue<PriorityQueueNode.Double<E
 	E pollElement();
 	
 	/**
+	 * Removes and returns the next (element, priority) pair in priority order from this PriorityQueueDouble,
+	 * adding a new (element, priority) pair prior to returning.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return the next (element, priority) pair in priority order, or null if empty prior to the call.
+	 */
+	default PriorityQueueNode.Double<E> pollThenAdd(PriorityQueueNode.Double<E> pair) {
+		PriorityQueueNode.Double<E> next = poll();
+		add(pair);
+		return next;
+	}
+	
+	/**
+	 * Removes and returns the next element in priority order from this PriorityQueueDouble,
+	 * adding a new (element, priority) pair to the PriorityQueueDouble with a specified priority.
+	 *
+	 * @param element The new element.
+	 * @param priority The priority of the new element.
+	 *
+	 * @return the next element in priority order, or null if empty.
+	 */
+	default E pollThenAdd(E element, double priority) {
+		E e = pollElement();
+		add(element, priority);
+		return e;
+	}
+	
+	/**
 	 * Promotes an element relative to priority order if the element is
 	 * present in the PriorityQueueDouble. For a min-heap, promotion means
 	 * decreasing the element's priority, while for a max-heap, promotion

--- a/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapDoubleTests.java
@@ -508,6 +508,107 @@ public class BinaryHeapDoubleTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testElementPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd("ZZZ", 1);
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd("YYY", 7);
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		s = pq.pollThenAdd("XXX", 9);
+		assertNull(s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd("XXX", 3);
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd("XXX", 3)
+		);
+	}
+	
+	@Test
+	public void testPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		BinaryHeapDouble<String> pq = BinaryHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("ZZZ", 1)).getElement();
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("YYY", 7)).getElement();
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		assertNull(pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 9)));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 3)).getElement();
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 3))
+		);
+	}
+	
+	@Test
 	public void testRemoveMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);

--- a/src/test/java/org/cicirello/ds/BinaryHeapTests.java
+++ b/src/test/java/org/cicirello/ds/BinaryHeapTests.java
@@ -509,6 +509,107 @@ public class BinaryHeapTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testElementPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd("ZZZ", 1);
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd("YYY", 7);
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		s = pq.pollThenAdd("XXX", 9);
+		assertNull(s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd("XXX", 3);
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd("XXX", 3)
+		);
+	}
+	
+	@Test
+	public void testPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		BinaryHeap<String> pq = BinaryHeap.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("ZZZ", 1)).getElement();
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("YYY", 7)).getElement();
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		assertNull(pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 9)));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 3)).getElement();
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 3))
+		);
+	}
+	
+	@Test
 	public void testRemoveMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);

--- a/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapDoubleTests.java
@@ -543,6 +543,107 @@ public class FibonacciHeapDoubleTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testElementPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd("ZZZ", 1);
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd("YYY", 7);
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		s = pq.pollThenAdd("XXX", 9);
+		assertNull(s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd("XXX", 3);
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd("XXX", 3)
+		);
+	}
+	
+	@Test
+	public void testPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		FibonacciHeapDouble<String> pq = FibonacciHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("ZZZ", 1)).getElement();
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("YYY", 7)).getElement();
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		assertNull(pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 9)));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 3)).getElement();
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 3))
+		);
+	}
+	
+	@Test
 	public void testRemoveMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);

--- a/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
+++ b/src/test/java/org/cicirello/ds/FibonacciHeapTests.java
@@ -544,6 +544,107 @@ public class FibonacciHeapTests {
 	// MIN HEAP TESTS
 	
 	@Test
+	public void testElementPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd("ZZZ", 1);
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd("YYY", 7);
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		s = pq.pollThenAdd("XXX", 9);
+		assertNull(s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd("XXX", 3);
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd("XXX", 3)
+		);
+	}
+	
+	@Test
+	public void testPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		int[] priorities = new int[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		FibonacciHeap<String> pq = FibonacciHeap.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("ZZZ", 1)).getElement();
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("YYY", 7)).getElement();
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		assertNull(pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 9)));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 3)).getElement();
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq.pollThenAdd(new PriorityQueueNode.Integer<String>("XXX", 3))
+		);
+	}
+	
+	@Test
 	public void testRemoveMinHeap() {
 		int n = 15;
 		String[] elements = createStrings(n);


### PR DESCRIPTION
## Summary
Added PriorityQueue.pollThenAdd and PriorityQueueDouble.pollThenAdd methods, including default implementation in the interfaces, and overridden implementation in the binary heap classes that exploit binary heap structure.

## Closing Issues
Closes #103 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
