### PR TITLE
Improved SimpleBinaryHeap.retainAll(Collection) and SimpleBinaryHeapDouble.retainAll(Collection)

### DIFF
--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.cicirello.util.Copyable;
-import org.cicirello.util.IntegerList;
 
 /**
  * <p>An implementation of a Binary Heap. An instance of a SimpleBinaryHeap
@@ -72,8 +71,8 @@ import org.cicirello.util.IntegerList;
  *     {@link #peekPriority(Object)}, {@link #promote}, {@link #remove(Object)}, {@link #toArray()}, {@link #toArray(Object[])}, 
  *     {@link #trimToSize}</li>
  * <li><b>O(n + m):</b> {@link #addAll(Collection)}, {@link #merge(SimpleBinaryHeap)}, 
- *     {@link #removeAll(Collection)}</li>
- * <li><b>O(nm):</b> {@link #containsAll(Collection)}, {@link #retainAll(Collection)}</li>
+ *     {@link #removeAll(Collection)}, {@link #retainAll(Collection)}</li>
+ * <li><b>O(nm):</b> {@link #containsAll(Collection)}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the SimpleBinaryHeap.
@@ -676,46 +675,39 @@ public final class SimpleBinaryHeap<E> implements MergeablePriorityQueue<E, Simp
 		return changed;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling remove repeatedly.</p>
+	 */
 	@Override
 	public final boolean retainAll(Collection<?> c) {
-		boolean[] keepThese = new boolean[size];
+		HashSet<Object> keepThese = new HashSet<Object>();
 		for (Object o : c) {
 			if (o instanceof PriorityQueueNode.Integer) {
 				PriorityQueueNode.Integer pair = (PriorityQueueNode.Integer)o;
-				for (int i = 0; i < size; i++) {
-					if (buffer[i].element.equals(pair.element)) {
-						keepThese[i] = true;
-					}
-				}
+				keepThese.add(pair.element);
 			} else {
-				for (int i = 0; i < size; i++) {
-					if (buffer[i].element.equals(o)) {
-						keepThese[i] = true;
-					}
-				}
+				keepThese.add(o);
 			}
 		}
-		IntegerList discardThese = new IntegerList(size);
-		for (int i = 0; i < size; i++) {
-			if (!keepThese[i]) {
-				discardThese.add(i);
-			}
-		}
-		if (discardThese.size() > 0) {
-			for (int i = discardThese.size()-1; i >= 0; i--) {
-				int j = discardThese.get(i);
+		boolean changed = false;
+		for (int i = size-1; i >= 0; i--) {
+			if (!keepThese.contains(buffer[i].element)) {
+				changed = true;
 				size--;
-				if (j == size) {
-					buffer[j] = null;
-				} else {
-					buffer[j] = buffer[size];
-					buffer[size] = null;
+				if (i != size) {
+					buffer[i] = buffer[size];
 				}
+				buffer[size] = null;
 			}
-			buildHeap();
-			return true;
 		}
-		return false;
+		if (changed) {
+			buildHeap();
+		}
+		return changed;
 	}
 	
 	@Override

--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.cicirello.util.Copyable;
-import org.cicirello.util.IntegerList;
 
 /**
  * <p>An implementation of a Binary Heap. An instance of a SimpleBinaryHeapDouble
@@ -72,8 +71,8 @@ import org.cicirello.util.IntegerList;
  *     {@link #peekPriority(Object)}, {@link #promote}, {@link #remove(Object)}, {@link #toArray()}, {@link #toArray(Object[])}, 
  *     {@link #trimToSize}</li>
  * <li><b>O(n + m):</b> {@link #addAll(Collection)}, {@link #merge(SimpleBinaryHeapDouble)}, 
- *     {@link #removeAll(Collection)}</li>
- * <li><b>O(nm):</b> {@link #containsAll(Collection)}, {@link #retainAll(Collection)}</li>
+ *     {@link #removeAll(Collection)}, {@link #retainAll(Collection)}</li>
+ * <li><b>O(nm):</b> {@link #containsAll(Collection)}</li>
  * </ul>
  *
  * @param <E> The type of object contained in the SimpleBinaryHeapDouble.
@@ -676,46 +675,39 @@ public final class SimpleBinaryHeapDouble<E> implements MergeablePriorityQueueDo
 		return changed;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling remove repeatedly.</p>
+	 */
 	@Override
 	public final boolean retainAll(Collection<?> c) {
-		boolean[] keepThese = new boolean[size];
+		HashSet<Object> keepThese = new HashSet<Object>();
 		for (Object o : c) {
 			if (o instanceof PriorityQueueNode.Double) {
 				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
-				for (int i = 0; i < size; i++) {
-					if (buffer[i].element.equals(pair.element)) {
-						keepThese[i] = true;
-					}
-				}
+				keepThese.add(pair.element);
 			} else {
-				for (int i = 0; i < size; i++) {
-					if (buffer[i].element.equals(o)) {
-						keepThese[i] = true;
-					}
-				}
+				keepThese.add(o);
 			}
 		}
-		IntegerList discardThese = new IntegerList(size);
-		for (int i = 0; i < size; i++) {
-			if (!keepThese[i]) {
-				discardThese.add(i);
-			}
-		}
-		if (discardThese.size() > 0) {
-			for (int i = discardThese.size()-1; i >= 0; i--) {
-				int j = discardThese.get(i);
+		boolean changed = false;
+		for (int i = size-1; i >= 0; i--) {
+			if (!keepThese.contains(buffer[i].element)) {
+				changed = true;
 				size--;
-				if (j == size) {
-					buffer[j] = null;
-				} else {
-					buffer[j] = buffer[size];
-					buffer[size] = null;
+				if (i != size) {
+					buffer[i] = buffer[size];
 				}
+				buffer[size] = null;
 			}
-			buildHeap();
-			return true;
 		}
-		return false;
+		if (changed) {
+			buildHeap();
+		}
+		return changed;
 	}
 	
 	@Override


### PR DESCRIPTION
## Summary
Improved runtime of SimpleBinaryHeap.retainAll(Collection) and SimpleBinaryHeapDouble.retainAll(Collection)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
