### PR TITLE
Update ahead of time jitpack snapshot build workflow

### DIFF
--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Request main-SNAPSHOT from JitPack
       run: |
         # timeout in 30 seconds to avoid waiting for build
-        curl -s -m 30 https://jitpack.io/org/cicirello/core/main-SNAPSHOT/ || true
+        curl -s -m 30 https://jitpack.io/org/cicirello/core/main-SNAPSHOT/maven-metadata.xml || true


### PR DESCRIPTION
## Summary
Improve consistency of ahead of time snapshot builds on jitpack by curling the maven metadata xml file rather than the directory of the latest snapshot.

## Closing Issues
Closes #113 
