### PR TITLE
Improved ahead of time jitpack builds during release workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -66,6 +66,6 @@ jobs:
 
     - name: Request release from JitPack to trigger build
       run: |
-        JITPACK_URL="https://jitpack.io/org/cicirello/core/${{ steps.get_version.outputs.VERSION }}/"
+        JITPACK_URL="https://jitpack.io/org/cicirello/core/${{ steps.get_version.outputs.VERSION }}/maven-metadata.xml"
         # timeout in 30 seconds to avoid waiting for build
         curl -s -m 30 ${JITPACK_URL} || true


### PR DESCRIPTION
## Summary
Improve consistency of ahead of time release builds on jitpack by curling the maven metadata xml file rather than the directory of the latest release.

## Closing Issues
Closes #114 
