### PR TITLE
Added SimpleFibonacciHeapDouble class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-09-14
+## [Unreleased] - 2022-09-15
 
 ### Added
 * SimpleBinaryHeap class: a basic implementation of a binary heap with integer priorities that allows 
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   speed advantage for operations like priority changes that constant time lookups provide.
 * SimpleBinaryHeapDouble class: a basic implementation of a binary heap with double priorities that allows 
   duplicate elements (unlike the BinaryHeapDouble class), but lacks constant time lookups and thus lacks the 
+  speed advantage for operations like priority changes that constant time lookups provide.
+* SimpleFibonacciHeapDouble class: a basic implementation of a Fibonacci heap with double priorities that allows 
+  duplicate elements (unlike the FibonacciHeapDouble class), but lacks constant time lookups and thus lacks the 
   speed advantage for operations like priority changes that constant time lookups provide.
 * PriorityQueue.pollThenAdd and PriorityQueueDouble.pollThenAdd methods, including default implementation in
   the interfaces, and overridden implementation in the binary heap classes that exploit binary heap structure.

--- a/src/main/java/org/cicirello/ds/BinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeap.java
@@ -65,8 +65,8 @@ import org.cicirello.util.Copyable;
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #add(Object, int)}, {@link #add(PriorityQueueNode.Integer)}, 
  *     {@link #change}, {@link #demote}, {@link #offer(Object, int)}, {@link #offer(PriorityQueueNode.Integer)},
- *     {@link #poll}, {@link #pollElement}, {@link #promote}, {@link #remove()}, {@link #remove(Object)}, 
- *     {@link #removeElement()}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #pollThenAdd(Object, int)}, {@link #pollThenAdd(PriorityQueueNode.Integer)},
+ *     {@link #promote}, {@link #remove()}, {@link #remove(Object)}, {@link #removeElement()}</li>
  * <li><b>O(m):</b> {@link #containsAll(Collection)}, {@link #createMaxHeap(Collection)}, 
  *     {@link #createMinHeap(Collection)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #copy()}, {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, 

--- a/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/BinaryHeapDouble.java
@@ -65,8 +65,8 @@ import org.cicirello.util.Copyable;
  *     {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #add(Object, double)}, {@link #add(PriorityQueueNode.Double)},
  *     {@link #change}, {@link #demote}, {@link #offer(Object, double)}, {@link #offer(PriorityQueueNode.Double)},
- *     {@link #poll}, {@link #pollElement}, {@link #promote}, {@link #remove()}, {@link #remove(Object)}, 
- *     {@link #removeElement()}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #pollThenAdd(Object, double)}, {@link #pollThenAdd(PriorityQueueNode.Double)},
+ *     {@link #promote}, {@link #remove()}, {@link #remove(Object)}, {@link #removeElement()}</li>
  * <li><b>O(m):</b> {@link #containsAll(Collection)}, {@link #createMaxHeap(Collection)}, 
  *     {@link #createMinHeap(Collection)}</li>
  * <li><b>O(n):</b> {@link #clear}, {@link #copy()}, {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, 

--- a/src/main/java/org/cicirello/ds/FibonacciHeap.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeap.java
@@ -73,7 +73,8 @@ import org.cicirello.util.Copyable;
  *     {@link #merge(FibonacciHeap)}, {@link #offer(E, int)}, {@link #offer(PriorityQueueNode.Integer)},
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(E)},
  *     {@link #promote}, {@link #size()}</li>
- * <li><b>O(lg n):</b> {@link #demote}, {@link #poll}, {@link #pollElement}, {@link #remove()},
+ * <li><b>O(lg n):</b> {@link #demote}, {@link #poll}, {@link #pollElement}, 
+ *      {@link #pollThenAdd(Object, int)}, {@link #pollThenAdd(PriorityQueueNode.Integer)}, {@link #remove()},
  *      {@link #remove(Object)}, {@link #removeElement()}</li> 
  * <li><b>O(m):</b> {@link #addAll(Collection)}, {@link #containsAll(Collection)}, 
  *     {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)}</li>

--- a/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
@@ -73,7 +73,8 @@ import org.cicirello.util.Copyable;
  *     {@link #merge(FibonacciHeapDouble)}, {@link #offer(E, double)}, {@link #offer(PriorityQueueNode.Double)},
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #peekPriority(E)},
  *     {@link #promote}, {@link #size()}</li>
- * <li><b>O(lg n):</b> {@link #demote}, {@link #poll}, {@link #pollElement}, {@link #remove()},
+ * <li><b>O(lg n):</b> {@link #demote}, {@link #poll}, {@link #pollElement}, 
+ *      {@link #pollThenAdd(Object, double)}, {@link #pollThenAdd(PriorityQueueNode.Double)}, {@link #remove()},
  *      {@link #remove(Object)}, {@link #removeElement()}</li> 
  * <li><b>O(m):</b> {@link #addAll(Collection)}, {@link #containsAll(Collection)}, 
  *     {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)}</li>

--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
@@ -62,8 +62,8 @@ import org.cicirello.util.Copyable;
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #add(Object, int)}, {@link #add(PriorityQueueNode.Integer)},
  *     {@link #offer(Object, int)}, {@link #offer(PriorityQueueNode.Integer)},
- *     {@link #poll}, {@link #pollElement}, {@link #remove()},  
- *     {@link #removeElement()}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #pollThenAdd(Object, int)}, {@link #pollThenAdd(PriorityQueueNode.Integer)},
+ *     {@link #remove()}, {@link #removeElement()}</li>
  * <li><b>O(m):</b> {@link #createMaxHeap(Collection)}, 
  *     {@link #createMinHeap(Collection)}</li>
  * <li><b>O(n):</b> {@link #change}, {@link #clear}, {@link #contains}, {@link #copy()}, {@link #demote}, {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, 
@@ -119,8 +119,7 @@ public final class SimpleBinaryHeap<E> implements MergeablePriorityQueue<E, Simp
 	 * @param initialElements The initial collection of (element, priority) pairs, which must be 
 	 * non-empty.
 	 *
-	 * @throws IllegalArgumentException if initialElements is empty, or if more than
-	 * one pair in initialElements contains the same element.
+	 * @throws IllegalArgumentException if initialElements is empty.
 	 */
 	private SimpleBinaryHeap(Collection<PriorityQueueNode.Integer<E>> initialElements) {
 		this(initialElements, (p1, p2) -> p1 < p2);

--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeap.java
@@ -24,7 +24,6 @@ package org.cicirello.ds;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
@@ -62,8 +62,8 @@ import org.cicirello.util.Copyable;
  *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()}, {@link #size()}</li>
  * <li><b>O(lg n):</b> {@link #add(Object, double)}, {@link #add(PriorityQueueNode.Double)},
  *     {@link #offer(Object, double)}, {@link #offer(PriorityQueueNode.Double)},
- *     {@link #poll}, {@link #pollElement}, {@link #remove()},  
- *     {@link #removeElement()}</li>
+ *     {@link #poll}, {@link #pollElement}, {@link #pollThenAdd(Object, double)}, {@link #pollThenAdd(PriorityQueueNode.Double)},
+ *     {@link #remove()}, {@link #removeElement()}</li>
  * <li><b>O(m):</b> {@link #createMaxHeap(Collection)}, 
  *     {@link #createMinHeap(Collection)}</li>
  * <li><b>O(n):</b> {@link #change}, {@link #clear}, {@link #contains}, {@link #copy()}, {@link #demote}, {@link #ensureCapacity}, {@link #equals}, {@link #hashCode}, 
@@ -119,8 +119,7 @@ public final class SimpleBinaryHeapDouble<E> implements MergeablePriorityQueueDo
 	 * @param initialElements The initial collection of (element, priority) pairs, which must be 
 	 * non-empty.
 	 *
-	 * @throws IllegalArgumentException if initialElements is empty, or if more than
-	 * one pair in initialElements contains the same element.
+	 * @throws IllegalArgumentException if initialElements is empty.
 	 */
 	private SimpleBinaryHeapDouble(Collection<PriorityQueueNode.Double<E>> initialElements) {
 		this(initialElements, (p1, p2) -> p1 < p2);

--- a/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/SimpleBinaryHeapDouble.java
@@ -24,7 +24,6 @@ package org.cicirello.ds;
 
 import java.lang.reflect.Array;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/src/main/java/org/cicirello/ds/SimpleFibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/SimpleFibonacciHeapDouble.java
@@ -1,0 +1,949 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import java.lang.reflect.Array;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Deque;
+import java.util.ArrayDeque;
+
+import org.cicirello.util.Copyable;
+
+/**
+ * <p>An implementation of a Fibonacci Heap. An instance of a SimpleFibonacciHeapDouble
+ * contains (element, priority) pairs, such that the priority values are of type double.</p> 
+ *
+ * <p><b>Origin:</b> Fibonacci heaps were first introduced in the following article:
+ * M. L. Fredman and R. E. Tarjan (1987). Fibonacci Heaps and Their Uses in Improved Network
+ * Optimization Algorithms. <i>Journal of the ACM</i>, 34(3): 596-615, July 1987.</p>
+ *
+ * <p>Consider using the {@link FibonacciHeapDouble} class instead if your application requires 
+ * any of the following: distinct elements, efficient containment checks, efficient priority
+ * increases or decreases, efficient arbitrary element removals. The {@link FibonacciHeapDouble}
+ * class can find an arbitrary element in constant time, making all of those operations faster.</p>
+ *
+ * <p><b>Priority order:</b>
+ * SimpleFibonacciHeapDouble instances are created via factory methods with names beginning
+ * with <code>create</code>. The priority order depends upon the factory method
+ * used to create the SimpleFibonacciHeapDouble. Methods named <code>createMinHeap</code> produce
+ * a min heap with priority order minimum-priority-first-out. Methods named 
+ * <code>createMaxHeap</code> produce a max heap with priority order 
+ * maximum-priority-first-out.</p>
+ *
+ * <p><b>Creating instances:</b> To create an instance, use one of the factory
+ * methods, such as with:</p>
+ * <pre><code>
+ * SimpleFibonacciHeapDouble&lt;String&gt; pq = SimpleFibonacciHeapDouble.createMinHeap();
+ * </code></pre>
+ *
+ * <p><b>Method runtimes:</b> The asymptotic runtime of the methods of
+ * this class are as follows (where n is the current size of the heap and m is the size of
+ * a Collection parameter where relevant). Note that in many cases in this list, the
+ * runtimes are amortized time and not actual time (see a reference on Fibonacci heaps for
+ * details).</p>
+ * <ul>
+ * <li><b>O(1):</b> {@link #add(Object, double)}, {@link #add(PriorityQueueNode.Double)}, 
+ *     {@link #createMaxHeap()}, 
+ *     {@link #createMinHeap()}, {@link #element}, {@link #isEmpty}, {@link #iterator},
+ *     {@link #merge(SimpleFibonacciHeapDouble)}, {@link #offer(E, double)}, {@link #offer(PriorityQueueNode.Double)},
+ *     {@link #peek}, {@link #peekElement}, {@link #peekPriority()},
+ *     {@link #size()}</li>
+ * <li><b>O(lg n):</b> {@link #poll}, {@link #pollElement}, {@link #pollThenAdd(Object, double)}, 
+ *      {@link #pollThenAdd(PriorityQueueNode.Double)}, {@link #remove()},
+ *      {@link #removeElement()}</li> 
+ * <li><b>O(m):</b> {@link #addAll(Collection)},  
+ *     {@link #createMaxHeap(Collection)}, {@link #createMinHeap(Collection)}</li>
+ * <li><b>O(n):</b> {@link #change}, {@link #clear}, {@link #contains}, {@link #copy()}, {@link #demote}, {@link #equals}, 
+ *     {@link #hashCode}, {@link #peekPriority(E)}, {@link #promote}, {@link #remove(Object)}, 
+ *     {@link #toArray()}, {@link #toArray(Object[])}</li>
+ * <li><b>O(n + m):</b> {@link #containsAll(Collection)}, {@link #removeAll(Collection)}, {@link #retainAll(Collection)}</li>
+ * </ul>
+ *
+ * @param <E> The type of object contained in the SimpleFibonacciHeapDouble.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
+ */
+public final class SimpleFibonacciHeapDouble<E> implements MergeablePriorityQueueDouble<E, SimpleFibonacciHeapDouble<E>>, Copyable<SimpleFibonacciHeapDouble<E>> {
+	
+	private final PriorityComparator compare;
+	private final double extreme;
+	
+	private int size;
+	private Node<E> min;
+	
+	// This array is what is referred to in CLRS description
+	// of algorithm as A in the method consolidate. As an optimization
+	// we construct the array once, and reuse it on all calls to consolidate.
+	private final Node<E>[] rootsByDegrees;
+	
+	private final static double INV_LOG_GOLDEN_RATIO = 2.0780869212350273;
+	
+	/* 
+	 * PRIVATE: Use factory methods for creation.
+	 *
+	 * Initializes an empty SimpleFibonacciHeapDouble.
+	 */
+	private SimpleFibonacciHeapDouble() {
+		this((p1, p2) -> p1 < p2);
+	}
+	
+	/* 
+	 * PRIVATE: Use factory methods for creation.
+	 *
+	 * Initializes an empty SimpleFibonacciHeapDouble.
+	 */
+	private SimpleFibonacciHeapDouble(PriorityComparator compare) {
+		this.compare = compare;
+		extreme = compare.comesBefore(0, 1) ? java.lang.Double.POSITIVE_INFINITY : java.lang.Double.NEGATIVE_INFINITY;
+		// length of array used by consolidate is initialized to 45 as follows:
+		// 1) since size is an int, the implicit limit on capacity is Integer.MAX_VALUE.
+		// 2) Thus, the highest that D(n) can be for a call to consolidate is:
+		//    floor(log(Integer.MAX_VALUE) / log((1+sqrt(5))/2)) = 44.
+		// 3) Array must be of length 1+D(n), so longest array must be is 45.
+		// 4) consolidate computes the actual D(n) for a specific call, and uses only
+		//    part of this array.
+		rootsByDegrees = nodeArrayAllocate(45);
+	}
+	
+	/* 
+	 * PRIVATE: Use factory methods for creation.
+	 * Initializes a SimpleFibonacciHeapDouble from a collection of (element, priority) pairs.
+	 *
+	 * @param initialElements The initial collection of (element, priority) pairs.
+	 *
+	 */
+	private SimpleFibonacciHeapDouble(Collection<PriorityQueueNode.Double<E>> initialElements) {
+		this(initialElements, (p1, p2) -> p1 < p2);
+	}
+	
+	/* 
+	 * PRIVATE: Use factory methods for creation.
+	 * Initializes a SimpleFibonacciHeapDouble from a collection of (element, priority) pairs.
+	 *
+	 * @param initialElements The initial collection of (element, priority) pairs.
+	 *
+	 */
+	private SimpleFibonacciHeapDouble(Collection<PriorityQueueNode.Double<E>> initialElements, PriorityComparator compare) {
+		this(compare);
+		for (PriorityQueueNode.Double<E> element : initialElements) {
+			internalOffer(element.copy());
+		}
+	}
+	
+	/*
+	 * private copy constructor to support the copy() method.
+	 */
+	private SimpleFibonacciHeapDouble(SimpleFibonacciHeapDouble<E> other) {
+		this(other.compare);
+		size = other.size;
+		min = other.min != null ? other.min.copy() : null;
+	}
+	
+	@Override
+	public SimpleFibonacciHeapDouble<E> copy() {
+		return new SimpleFibonacciHeapDouble<E>(this);
+	}
+	
+	/**
+	 * Creates an empty SimpleFibonacciHeapDouble with minimum-priority-first-out priority order.
+	 *
+	 * @param <E> The type of elements contained in the SimpleFibonacciHeapDouble.
+	 *
+	 * @return an empty SimpleFibonacciHeapDouble with a minimum-priority-first-out priority order
+	 */
+	public static <E> SimpleFibonacciHeapDouble<E> createMinHeap() {
+		return new SimpleFibonacciHeapDouble<E>();
+	}
+	
+	/**
+	 * Creates a SimpleFibonacciHeapDouble from a collection of (element, priority) pairs,
+	 * with a minimum-priority-first-out priority order.
+	 *
+	 * @param initialElements The initial collection of (element, priority) pairs.
+	 * @param <E> The type of elements contained in the SimpleFibonacciHeapDouble.
+	 *
+	 * @return a SimpleFibonacciHeapDouble with a minimum-priority-first-out priority order
+	 *
+	 */
+	public static <E> SimpleFibonacciHeapDouble<E> createMinHeap(Collection<PriorityQueueNode.Double<E>> initialElements) {
+		return new SimpleFibonacciHeapDouble<E>(initialElements);
+	}
+	
+	/**
+	 * Creates an empty SimpleFibonacciHeapDouble with maximum-priority-first-out priority order.
+	 *
+	 * @param <E> The type of elements contained in the SimpleFibonacciHeapDouble.
+	 *
+	 * @return an empty SimpleFibonacciHeapDouble with a maximum-priority-first-out priority order
+	 */
+	public static <E> SimpleFibonacciHeapDouble<E> createMaxHeap() {
+		return new SimpleFibonacciHeapDouble<E>((p1, p2) -> p1 > p2);
+	}
+	
+	/**
+	 * Creates a SimpleFibonacciHeapDouble from a collection of (element, priority) pairs,
+	 * with a maximum-priority-first-out priority order.
+	 *
+	 * @param initialElements The initial collection of (element, priority) pairs.
+	 * @param <E> The type of elements contained in the SimpleFibonacciHeapDouble.
+	 *
+	 * @return a SimpleFibonacciHeapDouble with a maximum-priority-first-out priority order
+	 *
+	 */
+	public static <E> SimpleFibonacciHeapDouble<E> createMaxHeap(Collection<PriorityQueueNode.Double<E>> initialElements) {
+		return new SimpleFibonacciHeapDouble<E>(initialElements, (p1, p2) -> p1 > p2);
+	}
+	
+	/**
+	 * <p>Adds an (element, priority) pair to the SimpleFibonacciHeapDouble with a specified priority.</p>
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added.
+	 */
+	@Override
+	public final boolean add(E element, double priority) {
+		return offer(element, priority);
+	}
+	
+	/**
+	 * <p>Adds an (element, priority) pair to the SimpleFibonacciHeapDouble.</p>
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added.
+	 *
+	 */
+	@Override
+	public final boolean add(PriorityQueueNode.Double<E> pair) {
+		return offer(pair);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>If it contains multiple entries for the element, the specific one
+	 * that it chooses to attempt to change is undefined.</p>
+	 */
+	@Override
+	public final boolean change(E element, double priority) {
+		Node<E> node = find(element);
+		if (node != null) {
+			if (compare.comesBefore(priority, node.e.value)) {
+				internalPromote(node, priority);
+				return true;
+			} else if (compare.comesBefore(node.e.value, priority)) {
+				internalDemote(node, priority);
+				return true;
+			}
+			return false;
+		}
+		return offer(element, priority);
+	}
+	
+	@Override
+	public final void clear() {
+		size = 0;
+		// set min to null which should cause garbage collection
+		// of entire fibonacci heap (impossible to have references to Nodes
+		// external from this class.
+		min = null;
+	}
+	
+	@Override
+	public final boolean contains(Object o) {
+		if (o instanceof PriorityQueueNode.Double) {
+			PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+			return find(pair.element) != null;
+		}
+		return find(o) != null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling {@link #contains(Object)} repeatedly.</p>
+	 */
+	@Override
+	public final boolean containsAll(Collection<?> c) {
+		HashSet<E> containsThese = new HashSet<E>();
+		for (PriorityQueueNode.Double<E> e : this) {
+			containsThese.add(e.element);
+		}
+		for (Object o : c) {
+			if (o instanceof PriorityQueueNode.Double) {
+				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+				if (!containsThese.contains(pair.element)){
+					return false;
+				}
+			} else if (!containsThese.contains(o)){
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>If it contains multiple entries for the element, the specific one
+	 * that it chooses to attempt to demote is undefined.</p>
+	 */
+	@Override
+	public final boolean demote(E element, double priority) {
+		Node<E> node = find(element);
+		if (node != null && compare.comesBefore(node.e.value, priority)) {
+			internalDemote(node, priority);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Checks if this SimpleFibonacciHeapDouble contains the same (element, priority)
+	 * pairs as another SimpleFibonacciHeapDouble, including the specific structure
+	 * the SimpleFibonacciHeapDouble, as well as that the priority order is the same.
+	 *
+	 * @param other The other SimpleFibonacciHeapDouble.
+	 *
+	 * @return true if and only if this and other contain the same (element, priority)
+	 * pairs, with the same priority order.
+	 */
+	@Override
+	public boolean equals(Object other) {
+		if (other == null) return false;
+		if (other instanceof SimpleFibonacciHeapDouble) {
+			@SuppressWarnings("unchecked")
+			SimpleFibonacciHeapDouble<E> casted = (SimpleFibonacciHeapDouble<E>)other;
+			if (size != casted.size) return false;
+			if (compare.comesBefore(0, 1) != casted.compare.comesBefore(0, 1)) return false;
+			Iterator<PriorityQueueNode.Double<E>> iter = iterator();
+			Iterator<PriorityQueueNode.Double<E>> otherIter = casted.iterator();
+			while (iter.hasNext()) {
+				if (!iter.next().equals(otherIter.next())) {
+					return false;
+				}
+			}
+			return true;
+		} else {
+			return false;
+		}
+	}
+	
+	/**
+	 * Computes a hashCode for the BinaryHeapDouble.
+	 *
+	 * @return a hashCode
+	 */
+	@Override
+	public int hashCode() {
+		int h = 0;
+		for (PriorityQueueNode.Double<E> e : this) {
+			h = 31 * h + java.lang.Double.hashCode(e.value);
+			h = 31 * h + e.element.hashCode();
+		}
+		return h;
+	}
+	
+	@Override
+	public final boolean isEmpty() {
+		return size == 0;
+	}
+	
+	@Override
+	public final Iterator<PriorityQueueNode.Double<E>> iterator() {
+		return new FibonacciHeapDoubleIterator();
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws IllegalArgumentException if this and other have different priority-order (e.g., one is a 
+	 * minheap while the other is a maxheap)
+	 */
+	@Override
+	public boolean merge(SimpleFibonacciHeapDouble<E> other) {
+		if (compare.comesBefore(0,1) != other.compare.comesBefore(0,1)) {
+			throw new IllegalArgumentException("this and other follow different priority-order");
+		}
+		if (other.size > 0) {
+			other.min.insertListInto(min);
+			if (compare.comesBefore(other.min.e.value, min.e.value)) {
+				min = other.min;
+			}
+			size += other.size;
+			other.clear();
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * Adds an (element, priority) pair to the SimpleFibonacciHeapDouble with a specified priority.
+	 *
+	 * @param element The element.
+	 * @param priority The priority of the element.
+	 *
+	 * @return true if the (element, priority) pair was added.
+	 */
+	@Override
+	public final boolean offer(E element, double priority) {
+		return internalOffer(new PriorityQueueNode.Double<E>(element, priority));
+	}
+	
+	/**
+	 * Adds an (element, priority) pair to the SimpleFibonacciHeapDouble.
+	 *
+	 * @param pair The (element, priority) pair to add.
+	 *
+	 * @return true if the (element, priority) pair was added.
+	 */
+	@Override
+	public final boolean offer(PriorityQueueNode.Double<E> pair) {
+		return internalOffer(pair.copy());
+	}
+	
+	@Override
+	public final E peekElement() {
+		return min != null ? min.e.element : null;
+	}
+	
+	@Override
+	public final PriorityQueueNode.Double<E> peek() {
+		return min != null ? min.e : null;
+	}
+	
+	@Override
+	public final double peekPriority() {
+		return min != null ? min.e.value : extreme;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>If it contains multiple entries for the element, it returns the
+	 * priority of one of them, but doesn't define which is chosen.</p>
+	 */
+	@Override
+	public final double peekPriority(E element) {
+		Node<E> node = find(element);
+		return node != null ? node.e.value : extreme;
+	}
+	
+	@Override
+	public final E pollElement() {
+		PriorityQueueNode.Double<E> min = poll();
+		return min != null ? min.element : null;
+	}
+	
+	@Override
+	public final PriorityQueueNode.Double<E> poll() {
+		if (size == 1) {
+			PriorityQueueNode.Double<E> pair = min.e;
+			min = null;
+			size = 0;
+			return pair;
+		} else if (size > 1) {
+			Node<E> z = min;
+			if (z.child != null) {
+				z.child.clearParentReferences();
+				z.child.insertListInto(min);
+			}
+			min = min.right;
+			z.left.right = min;
+			min.left  = z.left;
+			consolidate();
+			size--;
+			return z.e;
+		}
+		return null;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>If it contains multiple entries for the element, the specific one
+	 * that it chooses to attempt to promote is undefined.</p>
+	 */
+	@Override
+	public final boolean promote(E element, double priority) {
+		Node<E> node = find(element);
+		if (node != null && compare.comesBefore(priority, node.e.value)) {
+			internalPromote(node, priority);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>If it contains multiple entries for the element, it removes
+	 * one of them, but doesn't define which is removed.</p>
+	 */
+	@Override
+	public final boolean remove(Object o) {
+		Node<E> node = null;
+		if (o instanceof PriorityQueueNode.Double) {
+			PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+			node = find(pair.element);
+		} else {
+			node = find(o);
+		}
+		if (node == null) {
+			return false;
+		}
+		internalPromote(node, compare.comesBefore(min.e.value-1, min.e.value) ? min.e.value-1 : min.e.value+1);
+		poll();
+		return true;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling remove repeatedly.</p>
+	 */
+	@Override
+	public final boolean removeAll(Collection<?> c) {
+		HashSet<Object> discardThese = new HashSet<Object>();
+		for (Object o : c) {
+			if (o instanceof PriorityQueueNode.Double) {
+				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+				discardThese.add(pair.element);
+			} else {
+				discardThese.add(o);
+			}
+		}
+		ArrayList<PriorityQueueNode.Double<E>> keepList = new ArrayList<PriorityQueueNode.Double<E>>();
+		for (PriorityQueueNode.Double<E> e : this) {
+			if (!discardThese.contains(e.element)) {
+				keepList.add(e);
+			}
+		}
+		if (keepList.size() < size) {
+			clear();
+			for (PriorityQueueNode.Double<E> e : keepList) {
+				internalOffer(e);
+			}
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 *
+	 * <p>The runtime of this method is O(n + m) where n is current size
+	 * of the heap and m is the size of the Collection c. In general this
+	 * is more efficient than calling remove repeatedly.</p>
+	 */
+	@Override
+	public final boolean retainAll(Collection<?> c) {
+		HashSet<Object> keepThese = new HashSet<Object>();
+		for (Object o : c) {
+			if (o instanceof PriorityQueueNode.Double) {
+				PriorityQueueNode.Double pair = (PriorityQueueNode.Double)o;
+				keepThese.add(pair.element);
+			} else {
+				keepThese.add(o);
+			}
+		}
+		ArrayList<PriorityQueueNode.Double<E>> keepList = new ArrayList<PriorityQueueNode.Double<E>>(keepThese.size());
+		for (PriorityQueueNode.Double<E> e : this) {
+			if (keepThese.contains(e.element)) {
+				keepList.add(e);
+			}
+		}
+		if (keepList.size() < size) {
+			clear();
+			for (PriorityQueueNode.Double<E> e : keepList) {
+				internalOffer(e);
+			}
+			return true;
+		}
+		return false;
+	}
+	
+	@Override
+	public final int size() {
+		return size;
+	}
+	
+	@Override
+	public final Object[] toArray() {
+		Object[] array = new Object[size];
+		int i = 0;
+		for (PriorityQueueNode.Double<E> e : this) {
+			array[i] = e;
+			i++;
+		}
+		return array;
+	}
+	
+	@Override
+	public final <T> T[] toArray(T[] array) {
+		@SuppressWarnings("unchecked")
+		T[] result = array.length >= size ? array : (T[])Array.newInstance(array.getClass().getComponentType(), size);
+		int i = 0;
+		for (PriorityQueueNode.Double<E> e : this) {
+			@SuppressWarnings("unchecked")
+			T nextElement = (T)e;
+			result[i] = nextElement;
+			i++;
+		}
+		if (result.length > size) {
+			result[size] = null;
+		}
+		return result;
+	}
+	
+	private final Node<E> find(Object element) {
+		NodeIterator iter = new NodeIterator();
+		while (iter.hasNext()) {
+			Node<E> n  = iter.next();
+			if (n.e.element.equals(element)) {
+				return n;
+			}
+		}
+		return null;
+	}
+	
+	/*
+	 * used internally: doesn't check if already contains element
+	 */
+	private boolean internalOffer(PriorityQueueNode.Double<E> pair) {
+		if (min == null) {
+			min = new Node<E>(pair);
+			size = 1;
+		} else {
+			Node<E> added = new Node<E>(pair, min);
+			if (compare.comesBefore(pair.value, min.e.value)) {
+				min = added;
+			}
+			size++;
+		}
+		return true;
+	}
+	
+	private void internalPromote(Node<E> x, double priority) {
+		// only called if priority decreased for a minheap (increased for a maxheap)
+		// so no checks needed here.
+		x.e.value = priority;
+		Node<E> y = x.parent;
+		if (y != null && compare.comesBefore(priority, y.e.value)) {
+			cut(x, y);
+			cascadingCut(y);			
+		}
+		if (compare.comesBefore(priority, min.e.value)) {
+			min = x;
+		}
+	}
+	
+	private void internalDemote(Node<E> x, double priority) {
+		// only called if priority increased for a minheap (decreased for a maxheap)
+		// so no checks needed here.
+		
+		// 1. promote (opposite) to front
+		internalPromote(x, compare.comesBefore(min.e.value-1, min.e.value) ? min.e.value-1 : min.e.value+1);
+		// 2. poll() to remove
+		poll();
+		// 3. reinsert with new priority
+		x.e.value = priority;
+		internalOffer(x.e);
+	}
+	
+	private void cascadingCut(Node<E> y) {
+		Node<E> z = y.parent;
+		if (z != null) {
+			if (!y.mark) {
+				y.mark = true;
+			} else {
+				cut(y, z);
+				cascadingCut(z);
+			}
+		}
+	}
+	
+	private void cut(Node<E> x, Node<E> y) {
+		// 1. remove x from child list of y, decrementing degree of y
+		if (y.degree > 1) {
+			// ensure y's child reference isn't x
+			y.child = x.right;
+			// link x's left and right neighbors to remove x
+			x.left.right = x.right;
+			x.right.left = x.left;
+			y.degree--;
+		} else {
+			y.child = null;
+			y.degree = 0;
+		}
+		// 2. add x to the root list
+		x.insertInto(min);
+		x.parent = null;
+		x.mark = false;
+	}
+	
+	private void consolidate() {
+		int dn = (int)(Math.log(size) * INV_LOG_GOLDEN_RATIO);
+		
+		// first node of iteration
+		Node<E> w = min;
+		// disconnect from left to enable detecting end of list
+		w.left.right = null;
+		do{
+			Node<E> x = w;
+			// prepare for next iteration
+			w = w.right;
+			// disconnect x from root list
+			x.left = x.right = null;
+			
+			int d = x.degree;
+			while (rootsByDegrees[d] != null) {
+				Node<E> y = rootsByDegrees[d];
+				if (compare.comesBefore(y.e.value, x.e.value)) {
+					Node<E> temp = x;
+					x = y;
+					y = temp;
+				}
+				fibHeapLink(y, x);
+				rootsByDegrees[d] = null;
+				d++;
+			}
+			rootsByDegrees[d] = x;
+		} while (w != null);
+		
+		min = null;
+		for (int i = 0; i <= dn; i++) {
+			if (rootsByDegrees[i] != null) {
+				if (min == null) {
+					rootsByDegrees[i].singletonList();
+					min = rootsByDegrees[i];
+				} else {
+					rootsByDegrees[i].insertInto(min);
+					if (compare.comesBefore(rootsByDegrees[i].e.value, min.e.value)) {
+						min = rootsByDegrees[i];
+					}
+				}
+				// need this since this array is shared by all calls to consolidate
+				rootsByDegrees[i] = null;
+			}
+		}
+	}
+	
+	private void fibHeapLink(Node<E> y, Node<E> x) {
+		// 1. Remove y from root list step.
+		//    This is not needed because I'm instead
+		//    dismantling root list in consolidate
+		//    before rebuilding it.
+		// 2. Make y a child of x
+		if (x.degree > 0) {
+			y.insertInto(x.child);
+			y.parent = x;
+			x.degree++;
+		} else {
+			y.singletonList();
+			x.child = y;
+			y.parent = x;
+			x.degree = 1;
+		}
+		y.mark = false;
+	}
+	
+	private Node<E>[] nodeArrayAllocate(int n) {
+		@SuppressWarnings("unchecked")
+		Node<E>[] array = new Node[n];
+		return array;
+	}
+	
+	@FunctionalInterface
+	private static interface PriorityComparator {
+		boolean comesBefore(double p1, double p2);
+	}
+	
+	private class Node<E2> {
+		private PriorityQueueNode.Double<E2> e;
+		private Node<E2> parent;
+		private Node<E2> child;
+		private Node<E2> left;
+		private Node<E2> right;
+		private int degree;
+		private boolean mark;
+		
+		/*
+		 * new root list (i.e., called to create new top-level list when empty
+		 */
+		public Node(PriorityQueueNode.Double<E2> e) {
+			this.e = e;
+			singletonList();
+		}
+		
+		/*
+		 * adds newly constructed node to root list
+		 */
+		public Node(PriorityQueueNode.Double<E2> e, Node<E2> list) {
+			this.e = e;
+			insertInto(list);
+		}
+		
+		private Node(Node<E2> other) {
+			e = other.e.copy();
+			degree = other.degree;
+			mark = other.mark;
+		}
+		
+		private Node(Node<E2> other, Node<E2> toTheLeft) {
+			this(other);
+			left = toTheLeft;
+		}
+		
+		private Node<E2> copy() {
+			return copyList(this, null);
+		}
+		
+		private Node<E2> copyList(Node<E2> x, Node<E2> p) {
+			Node<E2> y = new Node<E2>(x);
+			y.parent = p;
+			if (x.child != null) {
+				y.child = copyList(x.child, y);
+			}
+			Node<E2> rightOf = y;
+			for (Node<E2> next = x.right; next != x; next = next.right, rightOf = rightOf.right) {
+				rightOf.right = new Node<E2>(next, rightOf);
+				rightOf.right.parent = p;
+				if (next.child != null) {
+					rightOf.right.child = copyList(next.child, rightOf.right);
+				}
+			}
+			rightOf.right = y;
+			y.left = rightOf;
+			return y;
+		}
+		
+		private void singletonList() {
+			left = right = this;
+		}
+
+		private void insertInto(Node<E2> list) {
+			right = list.right;
+			left = list;
+			list.right = list.right.left = this;
+		}
+		
+		private void insertListInto(Node<E2> list) {
+			list.right.left = left;
+			left.right = list.right;
+			list.right = this;
+			left = list;
+		}
+		
+		private void clearParentReferences() {
+			for (Node<E2> next = this; next.parent != null; next = next.right) {
+				next.parent = null;
+			}
+		}
+	}
+	
+	private class FibonacciHeapDoubleIterator implements Iterator<PriorityQueueNode.Double<E>> {
+		
+		private final Deque<Node<E>> stack;
+		
+		public FibonacciHeapDoubleIterator() {
+			stack = new ArrayDeque<Node<E>>(size);
+			if (size > 0) {
+				stack.push(min);
+				for (Node<E> next = min.right; next != min; next = next.right) {
+					stack.push(next);
+				}
+			}				
+		}
+		
+		@Override
+		public boolean hasNext() {
+			return !stack.isEmpty();
+		}
+		
+		@Override
+		public PriorityQueueNode.Double<E> next() {
+			// normally, the next method of an Iterator is
+			// required to throw NoSuchElementException is caled when empty.
+			// The pop() method of the ArrayDeque does this though. So no need
+			// for explicit check.
+			Node<E> current = stack.pop();
+			if (current.degree > 0) {
+				stack.push(current.child);
+				Node<E> next = current.child.right;
+				for (int i = 1; i < current.degree; i++, next = next.right) {
+					stack.push(next);
+				}
+			}
+			return current.e;
+		}
+	}
+	
+	private class NodeIterator implements Iterator<Node<E>> {
+		
+		private final Deque<Node<E>> stack;
+		
+		public NodeIterator() {
+			stack = new ArrayDeque<Node<E>>(size);
+			if (size > 0) {
+				stack.push(min);
+				for (Node<E> next = min.right; next != min; next = next.right) {
+					stack.push(next);
+				}
+			}				
+		}
+		
+		@Override
+		public boolean hasNext() {
+			return !stack.isEmpty();
+		}
+		
+		@Override
+		public Node<E> next() {
+			// normally, the next method of an Iterator is
+			// required to throw NoSuchElementException is called when empty.
+			// The pop() method of the ArrayDeque does this though. So no need
+			// for explicit check.
+			Node<E> current = stack.pop();
+			if (current.degree > 0) {
+				stack.push(current.child);
+				Node<E> next = current.child.right;
+				for (int i = 1; i < current.degree; i++, next = next.right) {
+					stack.push(next);
+				}
+			}
+			return current;
+		}
+	}
+}

--- a/src/test/java/org/cicirello/ds/SimpleFibonacciHeapDoubleTests.java
+++ b/src/test/java/org/cicirello/ds/SimpleFibonacciHeapDoubleTests.java
@@ -1,0 +1,2275 @@
+/*
+ * Module org.cicirello.core
+ * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of module org.cicirello.core.
+ *
+ * Module org.cicirello.core is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * Module org.cicirello.core is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with module org.cicirello.core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+package org.cicirello.ds;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * JUnit tests for the SimpleFibonacciHeapDouble class.
+ */
+public class SimpleFibonacciHeapDoubleTests {
+	
+	// TESTS THAT ARE NEITHER STRICTLY MIN HEAP TESTS NOW MAX HEAP TESTS
+	
+	@Test
+	public void testContainsAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		for (int i = 0; i < elements.length; i++) {
+			assertFalse(pq.containsAll(list));
+			assertTrue(pq.add(elements[i], priorities[i]));
+		}
+		assertTrue(pq.containsAll(list));
+	}
+	
+	@Test
+	public void testContainsAllElements() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		ArrayList<String> list = new ArrayList<String>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(elements[i]);
+		}
+		for (int i = 0; i < elements.length; i++) {
+			assertFalse(pq.containsAll(list));
+			assertTrue(pq.add(elements[i], priorities[i]));
+		}
+		assertTrue(pq.containsAll(list));
+	}
+	
+	@Test
+	public void testMerge() {
+		int n = 24;
+		String[] elements1 = new String[n];
+		double[] priorities1 = new double[n];
+		String[] elements2 = new String[n];
+		double[] priorities2 = new double[n];
+		ArrayList<PriorityQueueNode.Double<String>> list1 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list2 = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < 2*n; i+=2) {
+			elements1[i/2] = "A" + i;
+			elements2[i/2] = "A" + (i+1);
+			priorities1[i/2] = i;
+			priorities2[i/2] = i+1;
+			list1.add(new PriorityQueueNode.Double<String>(elements1[i/2], priorities1[i/2]));
+			list2.add(new PriorityQueueNode.Double<String>(elements2[i/2], priorities2[i/2]));
+		}
+		final SimpleFibonacciHeapDouble<String> pq1 = SimpleFibonacciHeapDouble.createMinHeap(list1);
+		final SimpleFibonacciHeapDouble<String> pq2 = SimpleFibonacciHeapDouble.createMinHeap(list2);
+		assertFalse(pq1.merge(SimpleFibonacciHeapDouble.createMinHeap()));
+		assertTrue(pq1.merge(pq2));
+		assertTrue(pq2.isEmpty());
+		assertEquals(0, pq2.size());
+		assertEquals(2*n, pq1.size());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq1.contains(elements1[i]));
+			assertTrue(pq1.contains(elements2[i]));
+			assertEquals(priorities1[i], pq1.peekPriority(elements1[i]));
+			assertEquals(priorities2[i], pq1.peekPriority(elements2[i]));
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(list1.get(i), pq1.poll());
+			assertEquals(list2.get(i), pq1.poll());
+		}
+		assertTrue(pq1.isEmpty());
+		assertEquals(0, pq1.size());
+		
+		IllegalArgumentException thrown = assertThrows( 
+			IllegalArgumentException.class,
+			() -> pq1.merge(SimpleFibonacciHeapDouble.createMaxHeap())
+		);
+	}
+	
+	@Test
+	public void testAddAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		
+		String[] elements2 = {"E", "F", "G", "H", "I"};
+		double[] priorities2 = { 7, 3, 1, 5, 9 };
+		ArrayList<PriorityQueueNode.Double<String>> list2 = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements2.length; i++) {
+			list2.add(new PriorityQueueNode.Double<String>(elements2[i], priorities2[i]));
+		}
+		assertTrue(pq.addAll(list2));
+		assertEquals(elements.length + elements2.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		for (int i = 0; i < elements2.length; i++) {
+			assertTrue(pq.contains(elements2[i]));
+			assertEquals(priorities2[i], pq.peekPriority(elements2[i]), 0.0);
+		}
+		
+		assertFalse(pq.addAll(new ArrayList<PriorityQueueNode.Double<String>>()));
+		assertEquals(elements.length + elements2.length, pq.size());
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		for (int i = 0; i < elements2.length; i++) {
+			assertTrue(pq.contains(elements2[i]));
+			assertEquals(priorities2[i], pq.peekPriority(elements2[i]), 0.0);
+		}
+	}
+	
+	@Test
+	public void testRetainAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		for (int i = 0; i < elements.length; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+		}
+		assertEquals(elements.length, pq.size());
+		String[] retain = {"E", "A", "F", "C"};
+		ArrayList<Object> keepThese = new ArrayList<Object>();
+		keepThese.add(elements[0]);
+		keepThese.add(elements[1]);
+		keepThese.add(elements[2]);
+		keepThese.add(elements[3]);
+		assertFalse(pq.retainAll(keepThese));
+		assertEquals(elements.length, pq.size());
+		
+		keepThese.clear();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[1]);
+		keepThese.add(new PriorityQueueNode.Double<String>(retain[2], 5));
+		keepThese.add(new PriorityQueueNode.Double<String>(retain[3], 15));
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(elements.length-2, pq.size());
+		assertTrue(pq.contains(elements[0]));
+		assertTrue(pq.contains(elements[2]));
+		assertFalse(pq.contains(elements[1]));
+		assertFalse(pq.contains(elements[3]));
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[1]);
+		keepThese.add(retain[3]);
+		assertFalse(pq.retainAll(keepThese));
+		
+		keepThese.clear();
+		keepThese.add(retain[0]);
+		keepThese.add(retain[2]);
+		assertTrue(pq.retainAll(keepThese));
+		assertEquals(0, pq.size());
+	}
+	
+	@Test
+	public void testRemoveAll() {
+		String[] elements = {"A", "B", "C", "D"};
+		double[] priorities = { 8, 6, 4, 2 };
+		final SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (int i = 0; i < elements.length; i++) {
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list));
+		assertEquals(0, pq.size());
+		for (String e : elements) {
+			assertFalse(pq.contains(e));
+		}
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list.remove(list.size()-1);
+		assertTrue(pq.removeAll(list));
+		assertEquals(1, pq.size());
+		for (int i = 0; i < elements.length-1; i++) {
+			String e = elements[i];
+			assertFalse(pq.contains(e));
+		}
+		assertTrue(pq.contains(elements[elements.length-1]));
+		
+		list.clear();
+		ArrayList<String> list2 = new ArrayList<String>();
+		ArrayList<String> list3 = new ArrayList<String>();
+		for (int i = 0; i < elements.length; i++) {
+			list2.add(elements[i]);
+			list3.add(elements[i]);
+			list.add(new PriorityQueueNode.Double<String>(elements[i], priorities[i]));
+		}
+		pq.clear();
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		assertTrue(pq.removeAll(list2));
+		assertEquals(0, pq.size());
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list2.remove(list.size()-1);
+		assertTrue(pq.removeAll(list2));
+		assertEquals(1, pq.size());
+		assertFalse(pq.removeAll(list2));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains(elements[elements.length-1]));
+		for (int i = 0; i < elements.length-1; i++) {
+			String e = elements[i];
+			assertFalse(pq.contains(e));
+		}
+		
+		pq.clear();
+		assertTrue(pq.addAll(list));
+		assertEquals(elements.length, pq.size());
+		list3.remove(0);
+		assertTrue(pq.removeAll(list3));
+		assertEquals(1, pq.size());
+		assertFalse(pq.removeAll(list3));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains(elements[0]));
+		for (int i = 1; i < elements.length; i++) {
+			String e = elements[i];
+			assertFalse(pq.contains(e));
+		}
+	}
+	
+	@Test
+	public void testIterator() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		for (int m = 0; m < n; m++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			int count = 0;
+			for (PriorityQueueNode.Double<String> e : pq) {
+				count++;
+			}
+			assertEquals(m, count);
+			count = 0;
+			final Iterator<PriorityQueueNode.Double<String>> iter = pq.iterator();
+			while (iter.hasNext()) {
+				PriorityQueueNode.Double<String> e = iter.next();
+				count++;
+			}
+			assertEquals(m, count);
+			NoSuchElementException thrown = assertThrows( 
+				NoSuchElementException.class,
+				() -> iter.next()
+			);
+		}
+	}
+	
+	@Test
+	public void testToArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		for (int m = 0; m < n; m++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			Object[] array = pq.toArray();
+			assertEquals(m, array.length);
+			int j = 0;
+			for (PriorityQueueNode.Double<String> e : pq) {
+				assertEquals(e, (PriorityQueueNode.Double)array[j]);
+				j++;
+			}
+		}
+	}
+	
+	@Test
+	public void testToArrayExistingArray() {
+		int n = 4;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		for (int m = 0; m <= n; m++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < m; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double[] a1 = new PriorityQueueNode.Double[n];
+			PriorityQueueNode.Double[] a2 = pq.toArray(a1);
+			assertTrue(a1 == a2);
+			int j = 0;
+			for (PriorityQueueNode.Double<String> e : pq) {
+				assertEquals(e, a2[j]);
+				j++;
+			}
+			assertEquals(m, j);
+			if (m<n) {
+				assertNull(a2[j]);
+			}
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		PriorityQueueNode.Double[] a1 = new PriorityQueueNode.Double[n-1];
+		PriorityQueueNode.Double[] a2 = pq.toArray(a1);
+		assertTrue(a1 != a2);
+		assertEquals(n, a2.length);
+		int j = 0;
+		for (PriorityQueueNode.Double<String> e : pq) {
+			assertEquals(e, a2[j]);
+			j++;
+		}
+		assertEquals(n, j);
+	}
+	
+	@Test
+	public void testClear() {
+		int n = 11;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap(list);
+		assertEquals(n, pq.size());
+		pq.clear();
+		assertEquals(0, pq.size());
+		for (int i = 0; i < n; i++) {
+			assertFalse(pq.contains(pairs[i].element));
+		}
+	}
+	
+	@Test
+	public void testCopy() {
+		int n = 11;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list1 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list2 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list3 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list4 = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list1.add(next);
+			list2.add(next);
+		}
+		for (int i = 0; i < n; i++) {
+			list3.add(new PriorityQueueNode.Double<String>(elements[i], 42));
+			list4.add(new PriorityQueueNode.Double<String>(elements[i], 42));
+		}
+		SimpleFibonacciHeapDouble<String> pq1 = SimpleFibonacciHeapDouble.createMinHeap(list1);
+		SimpleFibonacciHeapDouble<String> pq2 = SimpleFibonacciHeapDouble.createMaxHeap(list2);
+		SimpleFibonacciHeapDouble<String> pq3 = SimpleFibonacciHeapDouble.createMinHeap(list3);
+		SimpleFibonacciHeapDouble<String> pq4 = SimpleFibonacciHeapDouble.createMaxHeap(list4);
+		SimpleFibonacciHeapDouble<String> copy1 = pq1.copy();
+		SimpleFibonacciHeapDouble<String> copy2 = pq2.copy();
+		SimpleFibonacciHeapDouble<String> copy3 = pq3.copy();
+		SimpleFibonacciHeapDouble<String> copy4 = pq4.copy();
+		assertEquals(pq1, copy1);
+		assertEquals(pq2, copy2);
+		assertEquals(pq3, copy3);
+		assertEquals(pq4, copy4);
+		assertTrue(pq1 != copy1);
+		assertTrue(pq2 != copy2);
+		assertTrue(pq3 != copy3);
+		assertTrue(pq4 != copy4);
+		assertNotEquals(pq2, copy1);
+		assertNotEquals(pq3, copy1);
+		assertNotEquals(pq4, copy1);
+		assertNotEquals(pq1, copy2);
+		assertNotEquals(pq3, copy2);
+		assertNotEquals(pq4, copy2);
+		assertNotEquals(pq1, copy3);
+		assertNotEquals(pq2, copy3);
+		assertNotEquals(pq4, copy3);
+		assertNotEquals(pq1, copy4);
+		assertNotEquals(pq2, copy4);
+		assertNotEquals(pq3, copy4);
+	}
+	
+	@Test
+	public void testEqualsAndHashCode() {
+		int n = 11;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list1 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list2 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list3 = new ArrayList<PriorityQueueNode.Double<String>>();
+		ArrayList<PriorityQueueNode.Double<String>> list4 = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list1.add(next);
+			list2.add(next);
+			list3.add(next);
+			list4.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq1 = SimpleFibonacciHeapDouble.createMinHeap(list1);
+		SimpleFibonacciHeapDouble<String> pq2 = SimpleFibonacciHeapDouble.createMinHeap(list2);
+		SimpleFibonacciHeapDouble<String> pq3 = SimpleFibonacciHeapDouble.createMaxHeap(list3);
+		SimpleFibonacciHeapDouble<String> pq4 = SimpleFibonacciHeapDouble.createMaxHeap(list4);
+		assertEquals(pq1, pq2);
+		assertEquals(pq1.hashCode(), pq2.hashCode());
+		assertEquals(pq3, pq4);
+		assertEquals(pq3.hashCode(), pq4.hashCode());
+		assertNotEquals(pq1, pq3);
+		assertNotEquals(pq1.hashCode(), pq3.hashCode());
+		pq2.offer(""+((char)0), 0);
+		assertNotEquals(pq1, pq2);
+		assertNotEquals(pq1.hashCode(), pq2.hashCode());
+		pq1.offer(""+((char)0), 1);
+		assertNotEquals(pq1, pq2);
+		assertNotEquals(pq1.hashCode(), pq2.hashCode());
+		pq1.clear();
+		pq2.clear();
+		pq3.clear();
+		pq4.clear();
+		for (int i = 0; i < n; i++) {
+			pq1.offer(""+((char)('A'+i)), 42);
+			pq3.offer(""+((char)('A'+i)), 42);
+			pq2.offer(""+((char)('A'+(n-1)-i)), 42);
+			pq4.offer(""+((char)('A'+(n-1)-i)), 42);
+		}
+		assertNotEquals(pq1, pq3);
+		assertNotEquals(pq3, pq1);
+		assertNotEquals(pq3, pq4);
+		assertNotEquals(pq1, pq2);
+		assertNotEquals(pq1.hashCode(), pq2.hashCode());
+		assertNotEquals(pq3.hashCode(), pq4.hashCode());
+		assertNotEquals(pq1, null);
+		assertNotEquals(pq3, null);
+		assertNotEquals(pq1, "hello");
+		assertNotEquals(pq3, "hello");
+	}
+	
+	// MIN HEAP TESTS
+	
+	@Test
+	public void testElementPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd("ZZZ", 1);
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd("YYY", 7);
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		s = pq.pollThenAdd("XXX", 9);
+		assertNull(s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd("XXX", 3);
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+	}
+	
+	@Test
+	public void testPollThenAddMinHeap() {
+		int n = 7;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2*i+2;
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		for (int j = 0; j < n; j++) {
+			pq.offer(elements[j], priorities[j]);
+		}
+		// At front
+		String s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("ZZZ", 1)).getElement();
+		assertEquals(n, pq.size());
+		assertTrue(pq.contains("ZZZ"));
+		assertEquals(1, pq.peekPriority("ZZZ"));
+		assertEquals(elements[0], s);
+		assertEquals("ZZZ", pq.pollElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("YYY", 7)).getElement();
+		assertEquals(n-1, pq.size());
+		assertTrue(pq.contains("YYY"));
+		assertEquals(7, pq.peekPriority("YYY"));
+		assertEquals(elements[1], s);
+		assertEquals(elements[2], pq.pollElement());
+		assertEquals("YYY", pq.pollElement());
+		for (int i = 3; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+		}
+		assertEquals(0, pq.size());
+		assertNull(pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 9)));
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(9, pq.peekPriority("XXX"));
+		assertEquals(9, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		s = pq.pollThenAdd(new PriorityQueueNode.Double<String>("XXX", 3)).getElement();
+		assertEquals("XXX", s);
+		assertEquals(1, pq.size());
+		assertTrue(pq.contains("XXX"));
+		assertEquals(3, pq.peekPriority("XXX"));
+		assertEquals(3, pq.peekPriority());
+		assertEquals("XXX", pq.peekElement());
+		pq.offer("QQQ", 1);
+	}
+	
+	@Test
+	public void testRemoveMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = (2 + 2*i);
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			double[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			double[] p = {0, 3, 1, 7, 4, 5, 2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
+	
+	@Test
+	public void testChangePriorityMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change(elements[i], 1));
+			assertEquals(1.0, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change(elements[i], 100));
+			assertEquals(100.0, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (double p = 3; p <= maxP; p += 2.0) {
+			for (int i = 0; i < n; i++) {
+				SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				assertTrue(pq.change(elements[i], p));
+				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.change(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (double p = 1; p <= maxP; p += 2.0) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change("YYY", p));
+			assertEquals(p, pq.peekPriority("YYY"), 0.0);
+			int j = 0;
+			for (; j < n; j++) {
+				if (priorities[j] < p) {
+					assertEquals(elements[j], pq.pollElement());
+				} else {
+					break;
+				}
+			}
+			assertEquals("YYY", pq.pollElement());
+			for (; j < n; j++) {
+				if (priorities[j] > p) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMinHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = 2 + 2*i;
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], 1));
+			assertEquals(1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], 100));
+			assertEquals(100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (p < priorities[i]) {
+					assertTrue(pq.promote(elements[i], p));
+				} else {
+					assertTrue(pq.demote(elements[i], p));
+				}
+				assertEquals(p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] < p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] > p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testDefaultMinHeap() {
+		int n = 31;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testMinHeapAdd() {
+		int n = 31;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.add(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.add(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testDefaultMinHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRev(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
+			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testDefaultMinHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitrary(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'+i));
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMinHeap() {
+		int n = 31;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMinHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRev(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMinHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitrary(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'+i));
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'+i)), pq.poll());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testMinHeap() {
+		int n = 31;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[i], pq.pollElement());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMinHeapAdd2() {
+		int n = 31;
+		String[] elements = createStrings(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[i], pq.pollElement());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMinHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRev(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
+			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[n-1-i], pq.pollElement());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[n-1-i], pq.pollElement());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMinHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitrary(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMinHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.POSITIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'+i));
+			assertEquals(expected, pq.pollElement());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(expected, pq.pollElement());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	
+	// MAX HEAP TESTS
+	
+	@Test
+	public void testRemoveMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// Via element
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			assertTrue(pq.remove(elements[0]));
+			assertFalse(pq.contains(elements[0]));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(elements[0]));
+			assertEquals(0, pq.size());
+		}
+		// Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			assertTrue(pq.remove(elements[i]));
+			assertFalse(pq.contains(elements[i]));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(elements[i]));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			double[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			assertTrue(pq.remove(elements[3]));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// VIA PAIR
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], priorities[i]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// one element left via pair
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			pq.offer(elements[0], priorities[0]);
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[0], priorities[0]);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(0, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(0, pq.size());
+		}
+		// Via pair: Same priorities: no percolation needed
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], 42);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[i], 42);
+			assertTrue(pq.remove(pair));
+			assertFalse(pq.contains(pair));
+			assertEquals(n-1, pq.size());
+			assertFalse(pq.remove(pair));
+			assertEquals(n-1, pq.size());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertNotEquals(elements[i], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+		// Percolate Up Via Pair
+		{
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			double[] p = {0, -3, -1, -7, -4, -5, -2};
+			for (int i = 0; i < p.length; i++) {
+				pq.offer(elements[i], p[i]);
+			}
+			PriorityQueueNode.Double<String> pair = new PriorityQueueNode.Double<String>(elements[3], p[3]);
+			assertTrue(pq.remove(pair));
+			int[] expectedIndexOrder = {0, 2, 6, 1, 4, 5};
+			for (int i = 0; i < expectedIndexOrder.length; i++) {
+				assertEquals(elements[expectedIndexOrder[i]], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+			assertEquals(0, pq.size());
+		}
+	}
+	
+	@Test
+	public void testChangePriorityMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change(elements[i], -1));
+			assertEquals(-1.0, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change(elements[i], -100));
+			assertEquals(-100.0, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		int maxP = 2*(n-1) + 2;
+		for (double p = 3; p <= maxP; p += 2.0) {
+			for (int i = 0; i < n; i++) {
+				SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				assertTrue(pq.change(elements[i], -p));
+				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.change(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (double p = 1; p <= maxP; p += 2.0) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.change("YYY", -p));
+			assertEquals(-p, pq.peekPriority("YYY"), 0.0);
+			int j = 0;
+			for (; j < n; j++) {
+				if (priorities[j] > -p) {
+					assertEquals(elements[j], pq.pollElement());
+				} else {
+					break;
+				}
+			}
+			assertEquals("YYY", pq.pollElement());
+			for (; j < n; j++) {
+				if (priorities[j] < -p) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testPromoteDemoteMaxHeap() {
+		int n = 15;
+		String[] elements = createStrings(n);
+		double[] priorities = new double[n];
+		for (int i = 0; i < n; i++) {
+			priorities[i] = -(2 + 2*i);
+		}
+		// to front tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.promote(elements[i], -1));
+			assertEquals(-1, pq.peekPriority(elements[i]), 0.0);
+			assertEquals(elements[i], pq.pollElement());
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// to back tests
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertTrue(pq.demote(elements[i], -100));
+			assertEquals(-100, pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				if (i!=j) {
+					assertEquals(elements[j], pq.pollElement());
+				}
+			}
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.isEmpty());
+		}
+		// to interior tests
+		double maxP = 2*(n-1) + 2;
+		for (int p = 3; p <= maxP; p += 2) {
+			for (int i = 0; i < n; i++) {
+				SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+				for (int j = 0; j < n; j++) {
+					pq.offer(elements[j], priorities[j]);
+				}
+				if (-p > priorities[i]) {
+					assertTrue(pq.promote(elements[i], -p));
+				} else {
+					assertTrue(pq.demote(elements[i], -p));
+				}
+				assertEquals(-p, pq.peekPriority(elements[i]), 0.0);
+				int j = 0;
+				for (; j < n; j++) {
+					if (i != j) {
+						if (priorities[j] > -p) {
+							assertEquals(elements[j], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+						} else {
+							break;
+						}
+					}
+				}
+				assertEquals(elements[i], pq.pollElement(), "p,i,j="+p+","+i+","+j);
+				for (; j < n; j++) {
+					if (i!=j && priorities[j] < -p) {
+						assertEquals(elements[j], pq.pollElement());
+					}
+				}
+				assertTrue(pq.isEmpty());
+			}
+		}
+		// equal change test
+		for (int i = 0; i < n; i++) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			assertFalse(pq.demote(elements[i], priorities[i]));
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+		// new element test
+		maxP = 2*(n-1) + 3;
+		for (int p = 1; p <= maxP; p += 2) {
+			SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+			for (int j = 0; j < n; j++) {
+				pq.offer(elements[j], priorities[j]);
+			}
+			assertFalse(pq.promote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			assertFalse(pq.demote("YYY", -p));
+			assertFalse(pq.contains("YYY"));
+			for (int j = 0; j < n; j++) {
+				assertEquals(elements[j], pq.pollElement());
+			}
+			assertTrue(pq.isEmpty());
+		}
+	}
+	
+	@Test
+	public void testDefaultMaxHeap() {
+		int n = 31;
+		String[] elements = createStringsMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*n-2-2*i, pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testMaxHeapAdd() {
+		int n = 31;
+		String[] elements = createStringsMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.add(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.add(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*n-2-2*i, pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testDefaultMaxHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRevMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
+			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testDefaultMaxHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitraryMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'-i));
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMaxHeap() {
+		int n = 31;
+		String[] elements = createStringsMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[i], pq.poll());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[i], pq.poll());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMaxHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRevMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(pairs[n-1-i], pq.poll());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testListMaxHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitraryMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		ArrayList<PriorityQueueNode.Double<String>> list = new ArrayList<PriorityQueueNode.Double<String>>();
+		for (PriorityQueueNode.Double<String> next : pairs) {
+			list.add(next);
+		}
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap(list);
+		assertEquals(n, pq.size());
+		assertFalse(pq.isEmpty());
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(pairs[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'-i));
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(new PriorityQueueNode.Double<String>(expected, (int)('A'-i)), pq.poll());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.poll());
+	}
+	
+	@Test
+	public void testMaxHeap() {
+		int n = 31;
+		String[] elements = createStringsMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[i], pq.pollElement());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMaxHeapAdd2() {
+		int n = 31;
+		String[] elements = createStringsMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.add(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[0], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[i], pq.pollElement());
+			assertTrue(pq.contains(pairs[i].element));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[i], pq.pollElement());
+			assertFalse(pq.contains(pairs[i].element));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMaxHeapReverse() {
+		int n = 31;
+		String[] elements = createStringsRevMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+			assertEquals(elements[i], pq.peekElement());
+			assertEquals(pairs[i], pq.peek());
+			assertEquals((double)elements[i].charAt(0), pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(pairs[n-1], pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertEquals(elements[n-1-i], pq.pollElement());
+			assertTrue(pq.contains(elements[n-1-i]));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(elements[n-1-i], pq.pollElement());
+			assertFalse(pq.contains(elements[n-1-i]));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	@Test
+	public void testMaxHeapArbitrary() {
+		int n = 31;
+		String[] elements = createStringsArbitraryMaxCase(n);
+		double[] priorities = createPriorities(elements);
+		PriorityQueueNode.Double<String>[] pairs = createPairs(elements, priorities);
+		SimpleFibonacciHeapDouble<String> pq = SimpleFibonacciHeapDouble.createMaxHeap();
+		assertEquals(0, pq.size());
+		assertTrue(pq.isEmpty());
+		assertNull(pq.peekElement());
+		assertNull(pq.peek());
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority(), 0.0);
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(i+1, pq.size());
+			assertFalse(pq.isEmpty());
+		}
+		for (int i = 0; i < n; i++) {
+			assertTrue(pq.contains(elements[i]));
+			assertTrue(pq.contains(pairs[i]));
+			assertTrue(pq.offer(elements[i], priorities[i]));
+			assertEquals(n+i+1, pq.size());
+			assertEquals("A", pq.peekElement());
+			assertEquals(new PriorityQueueNode.Double<String>("A",(int)'A'), pq.peek());
+			assertEquals((double)'A', pq.peekPriority(), 0.0);
+		}
+		for (int i = 0; i < n; i++) {
+			assertEquals(priorities[i], pq.peekPriority(elements[i]), 0.0);
+		}
+		assertEquals(Double.NEGATIVE_INFINITY, pq.peekPriority("hello"), 0.0);
+		for (int i = 0; i < n; i++) {
+			String expected = ""+((char)('A'-i));
+			assertEquals(expected, pq.pollElement());
+			assertTrue(pq.contains(expected));
+			assertEquals(2*n-1-2*i, pq.size());
+			assertEquals(expected, pq.pollElement());
+			assertFalse(pq.contains(expected));
+			assertEquals(2*(n-1-i), pq.size());
+		}
+		assertNull(pq.pollElement());
+	}
+	
+	
+	private String[] createStrings(int n) {
+		String[] s = new String[n];
+		for (int i = 0; i < n; i++) {
+			s[i] = ((char)('A'+i)) + "";
+		}
+		return s;
+	}
+	
+	private String[] createStringsMaxCase(int n) {
+		String[] s = new String[n];
+		for (int i = 0; i < n; i++) {
+			s[i] = ((char)('A'-i)) + "";
+		}
+		return s;
+	}
+	
+	private double[] createPriorities(String[] elements) {
+		double[] p = new double[elements.length];
+		for (int i = 0; i < elements.length; i++) {
+			p[i] = (double)elements[i].charAt(0);
+		}
+		return p;
+	}
+	
+	private String[] createStringsRev(int n) {
+		String[] s = new String[n];
+		for (int i = 0; i < n; i++) {
+			s[n-1-i] = ((char)('A'+i)) + "";
+		}
+		return s;
+	}
+	
+	private String[] createStringsRevMaxCase(int n) {
+		String[] s = new String[n];
+		for (int i = 0; i < n; i++) {
+			s[n-1-i] = ((char)('A'-i)) + "";
+		}
+		return s;
+	}
+	
+	private String[] createStringsArbitrary(int n) {
+		ArrayList<String> list = new ArrayList<String>(n);
+		for (int i = 0; i < n; i++) {
+			list.add(((char)('A'+i)) + "");
+		}
+		Collections.shuffle(list);
+		return list.toArray(new String[n]);
+	}
+	
+	private String[] createStringsArbitraryMaxCase(int n) {
+		ArrayList<String> list = new ArrayList<String>(n);
+		for (int i = 0; i < n; i++) {
+			list.add(((char)('A'-i)) + "");
+		}
+		Collections.shuffle(list);
+		return list.toArray(new String[n]);
+	}
+	
+	private PriorityQueueNode.Double<String>[] createPairs(String[] elements, double[] priorities) {
+		@SuppressWarnings("unchecked")
+		PriorityQueueNode.Double<String>[] pairs = (PriorityQueueNode.Double<String>[])new PriorityQueueNode.Double[elements.length];
+		for (int i = 0; i < pairs.length; i++) {
+			pairs[i] = new PriorityQueueNode.Double<String>(elements[i], priorities[i]);
+		}
+		return pairs;
+	}
+}


### PR DESCRIPTION
## Summary
Added SimpleFibonacciHeapDouble class: a basic implementation of a Fibonacci heap with double priorities that allows duplicate elements (unlike the FibonacciHeapDouble class), but lacks constant time lookups and thus lacks the speed advantage for operations like priority changes that constant time lookups provide.

## Closing Issues
Closes #102 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
