### PR TITLE
Removed redundant implements in FibonacciHeapDouble class

### DIFF
--- a/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
+++ b/src/main/java/org/cicirello/ds/FibonacciHeapDouble.java
@@ -92,7 +92,7 @@ import org.cicirello.util.Copyable;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
  * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public final class FibonacciHeapDouble<E> extends SimpleFibonacciHeapDouble<E> implements MergeablePriorityQueueDouble<E, SimpleFibonacciHeapDouble<E>> {
+public final class FibonacciHeapDouble<E> extends SimpleFibonacciHeapDouble<E> {
 	
 	private HashMap<E, Node<E>> index;
 	


### PR DESCRIPTION
## Summary
Removed redundant implements declaration in FibonacciHeapDouble, which had simply repeated an implements declared in the superclass.

## Closing Issues
Closes #121 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
